### PR TITLE
Agent error handling should be improved

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ group :development, :test do
   gem 'minitest'
   gem 'minitest-reporters'
   gem 'minitest-debugger', :require => false
+  gem 'webmock'
 end
 
 group :development do

--- a/lib/instana.rb
+++ b/lib/instana.rb
@@ -17,14 +17,14 @@ module Instana
     # Initialize the Instana language agent
     #
     def start
-      Instana.agent = Instana::Agent.new
-      Instana.collectors = []
-      Instana.logger = Logger.new(STDOUT)
-      Instana.logger.info "Stan is on the scene.  Starting Instana instrumentation."
+      @agent = Instana::Agent.new
+      @collectors = []
+      @logger = Logger.new(STDOUT)
+      @logger.info "Stan is on the scene.  Starting Instana instrumentation."
 
       # Store the current pid so we can detect a potential fork
       # later on
-      Instana.pid = Process.pid
+      @pid = Process.pid
     end
 
     def pid_change?
@@ -33,14 +33,12 @@ module Instana
   end
 end
 
+
 require "instana/config"
 require "instana/agent"
 
 ::Instana.start
 
-if ::Instana.agent.host_agent_ready?
-  ::Instana.agent.announce_sensor
-  require "instana/collectors"
-else
-  ::Instana.logger.info "Instana host agent not available.  Going to sit in a corner quietly."
-end
+require "instana/collectors"
+
+::Instana.agent.start

--- a/lib/instana/agent.rb
+++ b/lib/instana/agent.rb
@@ -61,7 +61,7 @@ module Instana
             # If report has been failing for more than 1 minute,
             # fall back to unannounced state
             if (Time.now - @entity_last_seen) > 60
-              ::Instana.logger.debug "Metrics reporting failed for >1 min.  Falling back to announced."
+              ::Instana.logger.debug "Metrics reporting failed for >1 min.  Falling back to unannounced state."
               transition_to(:unannounced)
             end
           end
@@ -211,7 +211,7 @@ module Instana
       end
       response
     rescue Errno::ECONNREFUSED => e
-      Instana.logger.debug "Agent not responding: #{e.inspect}"
+      Instana.logger.debug "Agent not responding. Connection refused."
       return nil
     rescue
       Instana.logger.debug "Host agent request error: #{e.inspect}"

--- a/lib/instana/agent.rb
+++ b/lib/instana/agent.rb
@@ -206,14 +206,14 @@ module Instana
       req['Content-Type'] = 'application/json'
 
       response = nil
-      Net::HTTP.start(req.uri.hostname, req.uri.port) do |http|
+      Net::HTTP.start(req.uri.hostname, req.uri.port, :open_timeout => 1, :read_timeout => 1) do |http|
         response = http.request(req)
       end
       response
     rescue Errno::ECONNREFUSED => e
       Instana.logger.debug "Agent not responding. Connection refused."
       return nil
-    rescue
+    rescue => e
       Instana.logger.debug "Host agent request error: #{e.inspect}"
       return nil
     end

--- a/lib/instana/agent.rb
+++ b/lib/instana/agent.rb
@@ -1,12 +1,13 @@
 require 'net/http'
 require 'uri'
 require 'json'
+require 'timers'
 require 'sys/proctable'
 include Sys
 
 module Instana
   class Agent
-    attr_accessor :last_entity_response
+    attr_accessor :state
 
     def initialize
       # Host agent defaults.  Can be configured via Instana.config
@@ -15,6 +16,9 @@ module Instana
       @port = 42699
       @server_header = 'Instana Agent'
 
+      # Supported two states (unannounced & announced)
+      @state = :unannounced
+
       # Snapshot data is collected once per process but resent
       # every 10 minutes along side process metrics.
       @snapshot = take_snapshot
@@ -22,52 +26,62 @@ module Instana
       # Set last snapshot to 10 minutes ago
       # so we send a snapshot on first report
       @last_snapshot = Time.now - 601
+
+      # Timestamp of the last successful response from
+      # entity data reporting.
+      @entity_last_seen = Time.now
+
+      # Two timers, one for each state (unannounced & announced)
+      @timers = ::Timers::Group.new
+      @announce_timer = nil
+      @collect_timer = nil
     end
 
     ##
-    # take_snapshot
+    # start
     #
-    # Method to collect up process info for snapshots.  This
-    # is generally used once per process.
     #
-    def take_snapshot
-      data = {}
-
-      data[:sensorVersion] = ::Instana::VERSION
-      data[:pid] = Process.pid
-      data[:ruby_version] = RUBY_VERSION
-
-      process = ProcTable.ps(Process.pid)
-      arguments = process.cmdline.split(' ')
-      data[:name] = arguments.shift
-      data[:exec_args] = arguments
-
-      # Since a snapshot is only taken on process boot,
-      # this is ok here.
-      data[:start_time] = Time.now.to_s
-
-      # Framework Detection
-      if defined?(::RailsLts::VERSION)
-        data[:framework] = "Rails on Rails LTS-#{::RailsLts::VERSION}"
-
-      elsif defined?(::Rails.version)
-        data[:framework] = "Ruby on Rails #{::Rails.version}"
-
-      elsif defined?(::Grape::VERSION)
-        data[:framework] = "Grape #{::Grape::VERSION}"
-
-      elsif defined?(::Padrino::VERSION)
-        data[:framework] = "Padrino #{::Padrino::VERSION}"
-
-      elsif defined?(::Sinatra::VERSION)
-        data[:framework] = "Sinatra #{::Sinatra::VERSION}"
+    def start
+      # The announce timer
+      # We attempt to announce this ruby sensor to the host agent.
+      # In case of failure, we try again in 30 seconds.
+      @announce_timer = @timers.now_and_every(30) do
+        if host_agent_ready? && announce_sensor
+          ::Instana.logger.debug "Announce successful. Switching to metrics collection."
+          transition_to(:announced)
+        end
       end
 
-      data
-    rescue => e
-      ::Instana.logger.debug "#{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}"
-      ::Instana.logger.debug e.backtrace.join("\r\n")
-      return data
+      # The collect timer
+      # If we are in announced state, send metric data (only delta reporting)
+      # every ::Instana::Collector.interval seconds.
+      @collect_timer = @timers.every(::Instana::Collector.interval) do
+        if @state == :announced
+          unless ::Instana::Collector.collect_and_report
+            # If report has been failing for more than 1 minute,
+            # fall back to unannounced state
+            if (Time.now - @entity_last_seen) > 60
+              ::Instana.logger.debug "Metrics reporting failed for >1 min.  Falling back to announced."
+              transition_to(:unannounced)
+            end
+          end
+        end
+      end
+
+      # Start the background ruby sensor thread.  It works off of timers and
+      # is sleeping otherwise
+      Thread.new do
+        loop {
+          if @state == :unannounced
+            @collect_timer.pause
+            @announce_timer.resume
+          else
+            @announce_timer.pause
+            @collect_timer.resume
+          end
+          @timers.wait
+        }
+      end
     end
 
     ##
@@ -100,37 +114,36 @@ module Instana
     ##
     # report_entity_data
     #
-    # Method to report metrics data to the host agent.  Every 10 minutes, this
-    # method will also send a process snapshot data.
+    # Method to report metrics data to the host agent.
     #
     def report_entity_data(payload)
+      with_snapshot = false
       path = "com.instana.plugin.ruby.#{Process.pid}"
       uri = URI.parse("http://#{@host}:#{@port}/#{path}")
       req = Net::HTTP::Post.new(uri)
 
       # Every 5 minutes, send snapshot data as well
       if (Time.now - @last_snapshot) > 600
+        with_snapshot = true
         payload.merge!(@snapshot)
-        @last_snapshot = Time.now
       end
 
       req.body = payload.to_json
       response = make_host_agent_request(req)
 
-      if response && (response.code.to_i == 200)
-        # If snapshot data is in the payload and last response
-        # was ok then delete the snapshot data.  Otherwise let it
-        # ride for another run.
-        if payload.key?('sensorVersion')
-          @snapshot.each do |k, v|
-            payload.delete(k)
-          end
-        end
+      if response
+        last_entity_response = response.code.to_i
 
-        true
-      else
-        false
+        if last_entity_response == 200
+          @entity_last_seen = Time.now
+          @last_snapshot = Time.now if with_snapshot
+
+          #::Instana.logger.debug "entity response #{last_entity_response}: #{payload.to_json}"
+          return true
+        end
+        #::Instana.logger.debug "entity response #{last_entity_response}: #{payload.to_json}"
       end
+      false
     rescue => e
       Instana.logger.debug "#{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}"
       Instana.logger.debug e.backtrace.join("\r\n")
@@ -157,6 +170,31 @@ module Instana
     private
 
     ##
+    # transition_to
+    #
+    # Handles any/all steps required in the transtion
+    # between states.
+    #
+    def transition_to(state)
+      case state
+      when :announced
+        # announce successful; set state
+        @state = :announced
+
+        # Reset the entity timer
+        @entity_last_seen = Time.now
+
+        # Set last snapshot to 10 minutes ago
+        # so we send a snapshot on first report
+        @last_snapshot = Time.now - 601
+      when :unannounced
+        @state = :unannounced
+      else
+        ::Instana.logger.warn "Uknown agent state: #{state}"
+      end
+    end
+
+    ##
     # make host_agent_request
     #
     # Centralization of the net/http communications
@@ -178,6 +216,53 @@ module Instana
     rescue
       Instana.logger.debug "Host agent request error: #{e.inspect}"
       return nil
+    end
+
+    private
+    ##
+    # take_snapshot
+    #
+    # Method to collect up process info for snapshots.  This
+    # is generally used once per process.
+    #
+    def take_snapshot
+      data = {}
+
+      data[:sensorVersion] = ::Instana::VERSION
+      data[:pid] = ::Process.pid
+      data[:ruby_version] = RUBY_VERSION
+
+      process = ::ProcTable.ps(Process.pid)
+      arguments = process.cmdline.split(' ')
+      data[:name] = arguments.shift
+      data[:exec_args] = arguments
+
+      # Since a snapshot is only taken on process boot,
+      # this is ok here.
+      data[:start_time] = Time.now.to_s
+
+      # Framework Detection
+      if defined?(::RailsLts::VERSION)
+        data[:framework] = "Rails on Rails LTS-#{::RailsLts::VERSION}"
+
+      elsif defined?(::Rails.version)
+        data[:framework] = "Ruby on Rails #{::Rails.version}"
+
+      elsif defined?(::Grape::VERSION)
+        data[:framework] = "Grape #{::Grape::VERSION}"
+
+      elsif defined?(::Padrino::VERSION)
+        data[:framework] = "Padrino #{::Padrino::VERSION}"
+
+      elsif defined?(::Sinatra::VERSION)
+        data[:framework] = "Sinatra #{::Sinatra::VERSION}"
+      end
+
+      data
+    rescue => e
+      ::Instana.logger.debug "#{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}"
+      ::Instana.logger.debug e.backtrace.join("\r\n")
+      return data
     end
   end
 end

--- a/lib/instana/collectors.rb
+++ b/lib/instana/collectors.rb
@@ -7,6 +7,30 @@ module Instana
   module Collector
     class << self
       attr_accessor :interval
+      attr_accessor :snapshot
+
+      ##
+      # collect_and_report
+      #
+      # Run through each collector, let them collect up
+      # data and then report what we have via the agent
+      #
+      def collect_and_report
+        payload = {}
+
+        ::Instana.collectors.each do |c|
+          metrics = c.collect
+          if metrics
+            payload[c.payload_key] = metrics
+          else
+            payload.delete(c.payload_key)
+          end
+        end
+
+        # Report all the collected goodies
+        ::Instana.agent.report_entity_data(payload)
+      end
+
     end
   end
 end
@@ -15,33 +39,4 @@ if ENV.key?('INSTANA_GEM_DEV')
   ::Instana::Collector.interval = 3
 else
   ::Instana::Collector.interval = 1
-end
-
-::Thread.new do
-  timers = ::Timers::Group.new
-  payload = {}
-
-  timers.every(::Instana::Collector.interval) {
-
-    # Check if we forked (unicorn, puma) and
-    # if so, re-announce the process sensor
-    if ::Instana.pid_change?
-      ::Instana.logger.debug "Detected a fork (old: #{::Instana.pid} new: #{::Process.pid}).  Re-announcing sensor."
-      ::Instana.pid = Process.pid
-      Instana.agent.announce_sensor
-    end
-
-    ::Instana.collectors.each do |c|
-      metrics = c.collect
-      if metrics
-        payload[c.payload_key] = metrics
-      else
-        payload.delete(c.payload_key)
-      end
-    end
-
-    # Report all the collected goodies
-    ::Instana.agent.report_entity_data(payload)
-  }
-  loop { timers.wait }
 end

--- a/test/agent_test.rb
+++ b/test/agent_test.rb
@@ -1,0 +1,46 @@
+require 'test_helper'
+
+class AgentTest < Minitest::Test
+  def test_agent_host_detection
+    url = "http://#{::Instana.config[:agent_host]}:#{::Instana.config[:agent_port]}/"
+    stub_request(:get, url)
+    assert_equal true, ::Instana.agent.host_agent_ready?
+  end
+
+  def test_no_host_agent
+    url = "http://#{::Instana.config[:agent_host]}:#{::Instana.config[:agent_port]}/"
+    stub_request(:get, url).to_raise(Errno::ECONNREFUSED)
+    assert_equal false, ::Instana.agent.host_agent_ready?
+  end
+
+  def test_announce_sensor
+    url = "http://#{::Instana.config[:agent_host]}:#{::Instana.config[:agent_port]}/com.instana.plugin.ruby.discovery"
+    stub_request(:put, url)
+
+    assert_equal true, ::Instana.agent.announce_sensor
+  end
+
+  def test_failed_announce_sensor
+    url = "http://#{::Instana.config[:agent_host]}:#{::Instana.config[:agent_port]}/com.instana.plugin.ruby.discovery"
+    stub_request(:put, url).to_raise(Errno::ECONNREFUSED)
+
+    assert_equal false, ::Instana.agent.announce_sensor
+  end
+
+  def test_entity_data_report
+    url = "http://#{::Instana.config[:agent_host]}:#{::Instana.config[:agent_port]}/com.instana.plugin.ruby.#{Process.pid}"
+    stub_request(:post, url)
+
+    payload = { :test => 'true' }
+    assert_equal true, ::Instana.agent.report_entity_data(payload)
+  end
+
+  def test_failed_entity_data_report
+    url = "http://#{::Instana.config[:agent_host]}:#{::Instana.config[:agent_port]}/com.instana.plugin.ruby.#{Process.pid}"
+    stub_request(:post, url).to_raise(Errno::ECONNREFUSED)
+
+    payload = { :test => 'true' }
+    assert_equal false, ::Instana.agent.report_entity_data(payload)
+  end
+
+end

--- a/test/agent_test.rb
+++ b/test/agent_test.rb
@@ -43,4 +43,9 @@ class AgentTest < Minitest::Test
     assert_equal false, ::Instana.agent.report_entity_data(payload)
   end
 
+  def test_agent_timeout
+    url = "http://#{::Instana.config[:agent_host]}:#{::Instana.config[:agent_port]}/"
+    stub_request(:get, url).to_timeout
+    assert_equal false, ::Instana.agent.host_agent_ready?
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,6 +8,7 @@ require "minitest/spec"
 require "minitest/autorun"
 require "minitest/reporters"
 require "minitest/debugger" if ENV['DEBUG']
+require 'webmock/minitest'
 
 Minitest::Reporters.use! MiniTest::Reporters::SpecReporter.new
 


### PR DESCRIPTION
The Ruby code should 
1. detect when the host agent is offline and stop attempting to report metrics at least for a short period of time before a retry.
2. Periodically re-announce sensor when needed
3. Have a timeout for HTTP operations