### PR TITLE
Gem doesn't bind to host agent under Docker in bridged mode

### DIFF
--- a/lib/instana/agent.rb
+++ b/lib/instana/agent.rb
@@ -9,12 +9,13 @@ module Instana
   class Agent
     attr_accessor :state
 
+    LOCALHOST = '127.0.0.1'.freeze
+
     def initialize
       # Host agent defaults.  Can be configured via Instana.config
       @request_timeout = 5000
-      @host = '127.0.0.1'
+      @host = LOCALHOST
       @port = 42699
-      @server_header = 'Instana Agent'
 
       # Supported two states (unannounced & announced)
       @state = :unannounced
@@ -35,6 +36,13 @@ module Instana
       @timers = ::Timers::Group.new
       @announce_timer = nil
       @collect_timer = nil
+
+      # Detect if we're on linux or not (used in host_agent_ready?)
+      @is_linux = (RUBY_PLATFORM =~ /linux/i) ? true : false
+
+      # In case we're running in Docker, have the default gateway available
+      # to check in case we're running in bridged network mode
+      @default_gateway = `/sbin/ip route | awk '/default/ { print $3 }'`.chomp
     end
 
     ##
@@ -152,15 +160,36 @@ module Instana
     ##
     # host_agent_ready?
     #
-    # Check that the host agent is available and can be contacted.
+    # Check that the host agent is available and can be contacted.  This will
+    # first check localhost and if not, then attempt on the default gateway
+    # for docker in bridged mode.
     #
     def host_agent_ready?
-      uri = URI.parse("http://#{@host}:#{@port}/")
+      # Localhost
+      uri = URI.parse("http://#{LOCALHOST}:#{@port}/")
       req = Net::HTTP::Get.new(uri)
 
       response = make_host_agent_request(req)
 
-      (response && response.code.to_i == 200) ? true : false
+      if response && (response.code.to_i == 200)
+        @host = LOCALHOST
+        return true
+      end
+
+      return false unless @is_linux
+
+      # We are potentially running on Docker in bridged networking mode.
+      # Attempt to contact default gateway
+      uri = URI.parse("http://#{@default_gateway}:#{@port}/")
+      req = Net::HTTP::Get.new(uri)
+
+      response = make_host_agent_request(req)
+
+      if response && (response.code.to_i == 200)
+        @host = @default_gateway
+        return true
+      end
+      false
     rescue => e
       Instana.logger.debug "#{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}"
       Instana.logger.debug e.backtrace.join("\r\n")

--- a/lib/instana/agent.rb
+++ b/lib/instana/agent.rb
@@ -10,10 +10,11 @@ module Instana
     attr_accessor :state
 
     LOCALHOST = '127.0.0.1'.freeze
+    MIME_JSON = 'application/json'.freeze
+    DISCOVERY_PATH = 'com.instana.plugin.ruby.discovery'.freeze
 
     def initialize
       # Host agent defaults.  Can be configured via Instana.config
-      @request_timeout = 5000
       @host = LOCALHOST
       @port = 42699
 
@@ -107,8 +108,7 @@ module Instana
       arguments.shift
       announce_payload[:args] = arguments
 
-      path = 'com.instana.plugin.ruby.discovery'
-      uri = URI.parse("http://#{@host}:#{@port}/#{path}")
+      uri = URI.parse("http://#{@host}:#{@port}/#{DISCOVERY_PATH}")
       req = Net::HTTP::Put.new(uri)
       req.body = announce_payload.to_json
 
@@ -231,8 +231,8 @@ module Instana
     # of type Net::HTTP::Get|Put|Head
     #
     def make_host_agent_request(req)
-      req['Accept'] = 'application/json'
-      req['Content-Type'] = 'application/json'
+      req[:Accept] = MIME_JSON
+      req[:'Content-Type'] = MIME_JSON
 
       response = nil
       Net::HTTP.start(req.uri.hostname, req.uri.port, :open_timeout => 1, :read_timeout => 1) do |http|
@@ -247,7 +247,6 @@ module Instana
       return nil
     end
 
-    private
     ##
     # take_snapshot
     #

--- a/test/agent_test.rb
+++ b/test/agent_test.rb
@@ -8,8 +8,10 @@ class AgentTest < Minitest::Test
   end
 
   def test_no_host_agent
-    url = "http://#{::Instana.config[:agent_host]}:#{::Instana.config[:agent_port]}/"
-    stub_request(:get, url).to_raise(Errno::ECONNREFUSED)
+    localhost_url = "http://#{::Instana::Agent::LOCALHOST}:#{::Instana.config[:agent_port]}/"
+    stub_request(:get, localhost_url).to_raise(Errno::ECONNREFUSED)
+    docker_url = "http://#{::Instana.agent.instance_variable_get(:@default_gateway)}:#{::Instana.config[:agent_port]}/"
+    stub_request(:get, docker_url).to_timeout
     assert_equal false, ::Instana.agent.host_agent_ready?
   end
 
@@ -44,8 +46,10 @@ class AgentTest < Minitest::Test
   end
 
   def test_agent_timeout
-    url = "http://#{::Instana.config[:agent_host]}:#{::Instana.config[:agent_port]}/"
-    stub_request(:get, url).to_timeout
+    localhost_url = "http://#{::Instana::Agent::LOCALHOST}:#{::Instana.config[:agent_port]}/"
+    stub_request(:get, localhost_url).to_timeout
+    docker_url = "http://#{::Instana.agent.instance_variable_get(:@default_gateway)}:#{::Instana.config[:agent_port]}/"
+    stub_request(:get, docker_url).to_timeout
     assert_equal false, ::Instana.agent.host_agent_ready?
   end
 end


### PR DESCRIPTION
In the case of Docker running in bridged network mode, the gem still tries to communicate with 127.0.01 but instead it should use the default gateway.

https://stackoverflow.com/questions/24319662/from-inside-of-a-docker-container-how-do-i-connect-to-the-localhost-of-the-mach