### PR TITLE
Undocumented implicit dependency `ffi`

### DIFF
--- a/instana.gemspec
+++ b/instana.gemspec
@@ -35,4 +35,8 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency('sys-proctable', '>= 1.1.3')
   spec.add_runtime_dependency('get_process_mem', '>= 0.2.1')
   spec.add_runtime_dependency('timers', '>= 4.1.0')
+
+  # Indirect dependency
+  # https://github.com/instana/ruby-sensor/issues/10
+  spec.add_runtime_dependency('ffi', '>= 1.9.3')
 end


### PR DESCRIPTION
I just dropped this gem into a rails app.  The following `bundle install` command failed with the error message:

```
Installing hitimes 1.2.4 with native extensions
Installing get_process_mem 0.2.1
Your Gemfile.lock is corrupt. The following gem is missing from the DEPENDENCIES section: 'ffi'
```

Adding `ffi` to my Gemfile caused the bundle install to succeed.