### PR TITLE
Use proper logging log levels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,14 @@ cache:
   - vendor/bundle
 
 rvm:
-  - 2.3.1
+  - 2.3.2
+  - 2.2.6
+  - 2.1.9
+  - ruby-2.0.0-p648
 
 
 before_install:
-  - gem update --system '2.6.1'
+  - gem update --system
   - gem update bundler
   - gem --version
 

--- a/lib/instana.rb
+++ b/lib/instana.rb
@@ -19,8 +19,14 @@ module Instana
     def start
       @agent = Instana::Agent.new
       @collectors = []
+
       @logger = Logger.new(STDOUT)
-      @logger.info "Stan is on the scene.  Starting Instana instrumentation."
+      if ENV.key?('INSTANA_GEM_TEST') || ENV.key?('INSTANA_GEM_DEV')
+        @logger.level = Logger::DEBUG
+      else
+        @logger.level = Logger::WARN
+      end
+      @logger.unknown "Stan is on the scene.  Starting Instana instrumentation."
 
       # Store the current pid so we can detect a potential fork
       # later on

--- a/lib/instana/agent.rb
+++ b/lib/instana/agent.rb
@@ -137,7 +137,7 @@ module Instana
         false
       end
     rescue => e
-      Instana.logger.debug "#{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}"
+      Instana.logger.error "#{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}"
       Instana.logger.debug e.backtrace.join("\r\n")
       return false
     end
@@ -183,7 +183,7 @@ module Instana
       end
       false
     rescue => e
-      Instana.logger.debug "#{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}"
+      Instana.logger.error "#{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}"
       Instana.logger.debug e.backtrace.join("\r\n")
     end
 
@@ -222,7 +222,7 @@ module Instana
       end
       false
     rescue => e
-      Instana.logger.debug "#{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}"
+      Instana.logger.error "#{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}"
       Instana.logger.debug e.backtrace.join("\r\n")
       return false
     end
@@ -273,7 +273,7 @@ module Instana
     rescue Errno::ECONNREFUSED => e
       return nil
     rescue => e
-      Instana.logger.debug "#{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}"
+      Instana.logger.error "#{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}"
       Instana.logger.debug e.backtrace.join("\r\n")
       return nil
     end
@@ -336,7 +336,7 @@ module Instana
 
       data
     rescue => e
-      ::Instana.logger.debug "#{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}"
+      ::Instana.logger.error "#{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}"
       ::Instana.logger.debug e.backtrace.join("\r\n")
       return data
     end

--- a/lib/instana/collectors/gc.rb
+++ b/lib/instana/collectors/gc.rb
@@ -50,7 +50,7 @@ module Instana
           nil
         end
       rescue => e
-        ::Instana.logger.debug "#{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}"
+        ::Instana.logger.error "#{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}"
         ::Instana.logger.debug e.backtrace.join("\r\n")
       end
     end

--- a/lib/instana/collectors/memory.rb
+++ b/lib/instana/collectors/memory.rb
@@ -28,7 +28,7 @@ module Instana
           nil
         end
       rescue => e
-        ::Instana.logger.debug "#{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}"
+        ::Instana.logger.error "#{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}"
         ::Instana.logger.debug e.backtrace.join("\r\n")
       end
     end

--- a/lib/instana/collectors/thread.rb
+++ b/lib/instana/collectors/thread.rb
@@ -26,7 +26,7 @@ module Instana
           nil
         end
       rescue => e
-        ::Instana.logger.debug "#{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}"
+        ::Instana.logger.error "#{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}"
         ::Instana.logger.debug e.backtrace.join("\r\n")
       end
     end


### PR DESCRIPTION
Set the initial log level based on environment.  Update
code to use proper log levels in rescue blocks.