### PR TITLE
Ruby generating Trace IDs that are too large

### DIFF
--- a/lib/instana/tracing/trace.rb
+++ b/lib/instana/tracing/trace.rb
@@ -163,7 +163,8 @@ module Instana
     # @return [Integer] a random 64bit integer
     #
     def generate_id
-      rand(2**32..2**64-1)
+      # Max value is 9223372036854775807 (signed long in Java)
+      rand(2**32..2**63-1)
     end
   end
 end

--- a/test/tracing/trace_test.rb
+++ b/test/tracing/trace_test.rb
@@ -18,4 +18,13 @@ class TraceTest < Minitest::Test
     assert t.spans.size == 1
   end
 
+  def test_max_value_of_generated_id
+    t = ::Instana::Trace.new(:test_id)
+
+    # Max is the maximum value for a Java signed long
+    max_value = 9223372036854775807
+    100.times do
+      assert t.send(:generate_id) < max_value
+    end
+  end
 end


### PR DESCRIPTION
```
Numeric value (13086791889175417122) out of range of long (-9223372036854775808 - 9223372036854775807)
```

Need to limit the size that the ID generator generates.