### PR TITLE
Ruby Sensor not detecting/handling forking webservers correctly

### DIFF
--- a/lib/instana/agent.rb
+++ b/lib/instana/agent.rb
@@ -64,8 +64,16 @@ module Instana
     end
 
     def after_fork
+      @logger = Logger.new(STDOUT)
+      if ENV.key?('INSTANA_GEM_TEST') || ENV.key?('INSTANA_GEM_DEV')
+        @logger.level = Logger::DEBUG
+      else
+        @logger.level = Logger::WARN
+      end
       ::Instana.logger.debug "after_fork hook called. Falling back to unannounced state."
-      @state = :unannounced
+      ::Instana.logger.debug @announce_timer.inspect
+      ::Instana.logger.debug @collect_timer.inspect
+      transition_to(:unannounced)
 
       # Recollect process information
       @process = {}

--- a/lib/instana/agent.rb
+++ b/lib/instana/agent.rb
@@ -63,6 +63,21 @@ module Instana
       @process[:report_pid] = nil
     end
 
+    def after_fork
+      ::Instana.logger.debug "after_fork hook called. Falling back to unannounced state."
+      @state = :unannounced
+
+      # Recollect process information
+      @process = {}
+      cmdline = ProcTable.ps(Process.pid).cmdline.split("\0")
+      @process[:name] = cmdline.shift
+      @process[:arguments] = cmdline
+      @process[:original_pid] = Process.pid
+      # This is usually Process.pid but in the case of docker, the host agent
+      # will return to us the true host pid in which we use to report data.
+      @process[:report_pid] = nil
+    end
+
     # Sets up periodic timers and starts the agent in a background thread.
     #
     def start

--- a/test/tracing/trace_test.rb
+++ b/test/tracing/trace_test.rb
@@ -24,7 +24,7 @@ class TraceTest < Minitest::Test
     # Max is the maximum value for a Java signed long
     max_value = 9223372036854775807
     100.times do
-      assert t.send(:generate_id) < max_value
+      assert t.send(:generate_id) <= max_value
     end
   end
 end


### PR DESCRIPTION
This PR add support, detection and handling for forks (such as for forking webservers as unicorn/puma etc).  We fall back to unannounced state, re-initialize and then continue business as usual.

![screen shot 2016-11-24 at 16 10 06](https://cloud.githubusercontent.com/assets/395132/20603436/d57560b2-b261-11e6-9a44-5f97b998bb45.png)
