### PR TITLE
Agent background thread init/start should be configurable

### DIFF
--- a/lib/instana.rb
+++ b/lib/instana.rb
@@ -1,57 +1,13 @@
+require "instana/setup"
 
-require 'logger'
-require "instana/version"
-require "instana/util"
-
-module Instana
-  class << self
-    attr_accessor :agent
-    attr_accessor :collectors
-    attr_accessor :tracer
-    attr_accessor :processor
-    attr_accessor :config
-    attr_accessor :logger
-    attr_accessor :pid
-
-    ##
-    # start
-    #
-    # Initialize the Instana language agent
-    #
-    def start
-      @agent  = ::Instana::Agent.new
-      @tracer = ::Instana::Tracer.new
-      @processor = ::Instana::Processor.new
-      @collectors = []
-
-      @logger = Logger.new(STDOUT)
-      if ENV.key?('INSTANA_GEM_TEST') || ENV.key?('INSTANA_GEM_DEV')
-        @logger.level = Logger::DEBUG
-      else
-        @logger.level = Logger::WARN
-      end
-      @logger.unknown "Stan is on the scene.  Starting Instana instrumentation."
-
-      # Store the current pid so we can detect a potential fork
-      # later on
-      @pid = ::Process.pid
-    end
-
-    def pid_change?
-      @pid != ::Process.pid
-    end
-  end
+# Boot the instana agent background thread.  If you wish to have greater
+# control on the where and which thread this is run in, instead use
+#
+#   gem "instana", :require "instana/setup"
+#
+# ...and manually call ::Instana.agent.start in the thread
+# of your choice
+#
+Thread.new do
+  ::Instana.agent.start
 end
-
-
-require "instana/config"
-require "instana/agent"
-require "instana/tracer"
-require "instana/tracing/processor"
-
-::Instana.start
-
-require "instana/collectors"
-require "instana/instrumentation"
-
-::Instana.agent.start

--- a/lib/instana/agent.rb
+++ b/lib/instana/agent.rb
@@ -110,7 +110,7 @@ module Instana
 
     # Sets up periodic timers and starts the agent in a background thread.
     #
-    def start
+    def setup
       # The announce timer
       # We attempt to announce this ruby sensor to the host agent.
       # In case of failure, we try again in 30 seconds.
@@ -146,20 +146,23 @@ module Instana
         end
       end
 
-      # Start the background ruby sensor thread.  It works off of timers and
-      # is sleeping otherwise
-      Thread.new do
-        loop {
-          if @state == :unannounced
-            @collect_timer.pause
-            @announce_timer.resume
-          else
-            @announce_timer.pause
-            @collect_timer.resume
-          end
-          @timers.wait
-        }
-      end
+    end
+
+    # Starts the timer loop for the timers that were initialized
+    # in the setup method.  This is blocking and should only be
+    # called from an already initialized background thread.
+    #
+    def start
+      loop {
+        if @state == :unannounced
+          @collect_timer.pause
+          @announce_timer.resume
+        else
+          @announce_timer.pause
+          @collect_timer.resume
+        end
+        @timers.wait
+      }
     end
 
     # Indicates if the agent is ready to send metrics

--- a/lib/instana/base.rb
+++ b/lib/instana/base.rb
@@ -1,0 +1,44 @@
+require 'logger'
+require "instana/version"
+require "instana/util"
+
+module Instana
+  class << self
+    attr_accessor :agent
+    attr_accessor :collectors
+    attr_accessor :tracer
+    attr_accessor :processor
+    attr_accessor :config
+    attr_accessor :logger
+    attr_accessor :pid
+
+    ##
+    # setup
+    #
+    # Setup the Instana language agent to an informal "ready
+    # to run" state.
+    #
+    def setup
+      @agent  = ::Instana::Agent.new
+      @tracer = ::Instana::Tracer.new
+      @processor = ::Instana::Processor.new
+      @collectors = []
+
+      @logger = Logger.new(STDOUT)
+      if ENV.key?('INSTANA_GEM_TEST') || ENV.key?('INSTANA_GEM_DEV')
+        @logger.level = Logger::DEBUG
+      else
+        @logger.level = Logger::WARN
+      end
+      @logger.unknown "Stan is on the scene.  Starting Instana instrumentation."
+
+      # Store the current pid so we can detect a potential fork
+      # later on
+      @pid = ::Process.pid
+    end
+
+    def pid_change?
+      @pid != ::Process.pid
+    end
+  end
+end

--- a/lib/instana/setup.rb
+++ b/lib/instana/setup.rb
@@ -1,0 +1,25 @@
+require "instana/base"
+require "instana/config"
+require "instana/agent"
+require "instana/tracer"
+require "instana/tracing/processor"
+
+::Instana.setup
+
+require "instana/collectors"
+require "instana/instrumentation"
+
+::Instana.agent.setup
+
+# The Instana agent is now setup.  The only remaining
+# task for a complete boot is to call
+# `Instana.agent.start` in the thread of your choice.
+# This can be in a simple `Thread.new` block or
+# any other thread system you may use (e.g. actor
+# threads).
+#
+# Note that `start` should only be called once per process.
+#
+# Thread.new do
+#   ::Instana.agent.start
+# end


### PR DESCRIPTION
Per feedback from @ntl.  The Ruby sensor should have a way to optionally control when/how the background thread is started/executed.  The current default is acceptable but having a secondary option per require option in the Gemfile would be ideal:

`gem "instana", :require "instana/setup"`

This would do basic initialization but not boot/execute the background thread.  With this option, the user can control where/how the background thread is run/manages.

