### PR TITLE
Traces aren't using the full range of IDs possible

### DIFF
--- a/lib/instana/tracer.rb
+++ b/lib/instana/tracer.rb
@@ -152,7 +152,10 @@ module Instana
         Instana.logger.debug "id_to_header received a #{id.class}: returning empty string"
         return String.new
       end
-      id.to_i.to_s(16)
+      [id.to_i].pack('q>').unpack('H*')[0]
+    rescue => e
+      Instana.logger.error "#{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}"
+      Instana.logger.debug e.backtrace.join("\r\n")
     end
 
     # Convert a received header value into a valid ID
@@ -166,7 +169,10 @@ module Instana
         Instana.logger.debug "header_to_id received a #{header_id.class}: returning 0"
         return 0
       end
-      header_id.to_i(16)
+      [header_id].pack("H*").unpack("q>")[0]
+    rescue => e
+      Instana.logger.error "#{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}"
+      Instana.logger.debug e.backtrace.join("\r\n")
     end
 
     # Returns the trace ID for the active trace (if there is one),

--- a/lib/instana/tracing/trace.rb
+++ b/lib/instana/tracing/trace.rb
@@ -164,7 +164,7 @@ module Instana
     #
     def generate_id
       # Max value is 9223372036854775807 (signed long in Java)
-      rand(2**32..2**63-1)
+      rand(-2**63..2**63-1)
     end
   end
 end


### PR DESCRIPTION
The Ruby agent generates IDs for traces.  We're currently only generating a subset of the total IDs possible.