### PR TITLE
Traces are not flushed for short-lived ruby scripts

### DIFF
--- a/lib/instana/agent.rb
+++ b/lib/instana/agent.rb
@@ -160,6 +160,16 @@ module Instana
           @timers.wait
         }
       end
+    ensure
+      if @state == :announced
+        # Pause the timers so they don't fire while we are
+        # reporting traces
+        @collect_timer.pause
+        @announce_timer.pause
+
+        ::Instana.logger.debug "Instana: Agent exiting. Reporting final #{::Instana.processor.queue_count} trace(s)."
+        ::Instana.processor.send
+      end
     end
 
     # Indicates if the agent is ready to send metrics

--- a/lib/instana/tracing/processor.rb
+++ b/lib/instana/tracing/processor.rb
@@ -30,7 +30,7 @@ module Instana
       return if @queue.empty?
 
       size = @queue.size
-      if size > 10
+      if size > 100
         Instana.logger.debug "Trace queue is #{size}"
       end
 


### PR DESCRIPTION
For quick ruby scripts, traces in queue are destroyed along with the process & threads.  We should add an ensure block to the thread loop to make sure traces/metrics are flushed to the host agent before exiting.