### PR TITLE
Custom Instana logger for better logging control

### DIFF
--- a/Configuration.md
+++ b/Configuration.md
@@ -1,0 +1,53 @@
+# Configuration
+
+## Logging
+
+The Instana logger is a standard Ruby logger that logs debug, warn, info
+(etc.) messages and can be set as follows:
+
+```Ruby
+require "logger"
+::Instana.logger.level = ::Logger::WARN
+```
+
+It also allows the debug level to be configured that affects
+what extra debug info it reports.  It allows for:
+
+* `:agent` - shows all agent state related debug messages
+* `:agent_comm` - outputs all request/response pairs to and from the
+  host agent
+
+Log messages can be generated for these channels using:
+
+```Ruby
+::Instana.logger.agent("agent specific log msg")
+::Instana.logger.agent_comm("agent communication specific log msg")
+```
+
+To set the debug log level:
+
+```Ruby
+::Instana.logger.debug_level = [:agent, :agent_comm]
+# or
+::Instana.logger.debug_level = [:agent_comm]
+# or
+::Instana.logger.debug_level = :agent
+```
+
+or to reset it:
+
+```Ruby
+::Instana.logger.debug_level = nil
+```
+
+Example output:
+```bash
+[2] pry(main)> Instana.logger.debug_level = :agent_comm
+=> :agent_comm
+
+D, [2016-12-01T11:45:12.876527 #74127] DEBUG -- : Instana: POST Req -> -body-: http://127.0.0.1:42699/com.instana.plugin.ruby.74127 ->
+-{"gc":{"heap_live":171890,"heap_free":522},"memory":{"rss_size":51212.0}}- Resp -> body:#<Net::HTTPOK:0x007faee2161078> -> -[]-
+
+[3] pry(main)> Instana.logger.debug_level = nil
+=> nil
+```

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 group :development, :test do
   gem 'rake'
-  gem 'minitest'
+  gem 'minitest', '5.9.1'
   gem 'minitest-reporters'
   gem 'minitest-debugger', :require => false
   gem 'rack-test'

--- a/lib/instana/base.rb
+++ b/lib/instana/base.rb
@@ -1,5 +1,5 @@
-require 'logger'
 require "instana/version"
+require 'instana/logger'
 require "instana/util"
 
 module Instana
@@ -19,7 +19,7 @@ module Instana
     # to run" state.
     #
     def setup
-      @logger = Logger.new(STDOUT)
+      @logger = ::Instana::XLogger.new(STDOUT)
       if ENV.key?('INSTANA_GEM_TEST') || ENV.key?('INSTANA_GEM_DEV')
         @logger.level = Logger::DEBUG
       else

--- a/lib/instana/logger.rb
+++ b/lib/instana/logger.rb
@@ -1,0 +1,58 @@
+require "logger"
+
+module Instana
+  class XLogger < Logger
+    LEVELS = [:agent, :agent_comm].freeze
+    STAMP = "Instana: ".freeze
+
+    def initialize(*args)
+      if ENV['INSTANA_GEM_DEV']
+        self.debug_level=:agent
+      end
+      super(*args)
+    end
+
+    def debug_level=(levels)
+      LEVELS.each do |l|
+        instance_variable_set("@level_#{l}", false)
+      end
+
+      levels = [ levels ] unless levels.is_a?(Array)
+      levels.each do |l|
+        next unless LEVELS.include?(l)
+        instance_variable_set("@level_#{l}", true)
+      end
+    end
+
+    def agent(msg)
+      return unless @level_agent
+      self.debug(msg)
+    end
+
+    def agent_comm(msg)
+      return unless @level_agent_comm
+      self.debug(msg)
+    end
+
+    def error(msg)
+      super(STAMP + msg)
+    end
+
+    def warn(msg)
+      super(STAMP + msg)
+    end
+
+    def info(msg)
+      super(STAMP + msg)
+    end
+
+    def debug(msg)
+      super(STAMP + msg)
+    end
+
+    def unkown(msg)
+      super(STAMP + msg)
+    end
+  end
+end
+


### PR DESCRIPTION
This logger allows the debug level to be configured that affects
what it reports.  For this first iteration, it allows for:

* `:agent` - shows all agent state related debug messages
* `:agent_comm` - outputs all request/response pairs to and from the host agent

Log messages can be generated for these channels using:

```Ruby
::Instana.logger.agent("agent specific log msg")
::Instana.logger.agent_comm("agent communication specific log msg")
```

To set the debug log level:

```Ruby
::Instana.logger.debug_level = [:agent, :agent_comm]
# or
::Instana.logger.debug_level = [:agent_comm]
# or
::Instana.logger.debug_level = :agent
```

or to reset it:

```Ruby
::Instana.logger.debug_level = nil
```