### PR TITLE
Change RestClient instrumentation to report using SDK

### DIFF
--- a/lib/instana/collectors.rb
+++ b/lib/instana/collectors.rb
@@ -28,7 +28,7 @@ module Instana
         end
 
         # Report all the collected goodies
-        ::Instana.agent.report_entity_data(payload)
+        ::Instana.agent.report_entity_data(payload) unless ENV['INSTANA_GEM_TEST']
       end
 
     end

--- a/lib/instana/tracing/processor.rb
+++ b/lib/instana/tracing/processor.rb
@@ -72,7 +72,7 @@ module Instana
     #   - Prevent another run of the timer while this is running
     #
     def send
-      return if @queue.empty?
+      return if @queue.empty? || ENV['INSTANA_GEM_TEST']
 
       size = @queue.size
       if size > 100

--- a/lib/instana/tracing/trace.rb
+++ b/lib/instana/tracing/trace.rb
@@ -1,6 +1,6 @@
 module Instana
   class Trace
-    REGISTERED_SPANS = [ :rack, :'net-http', :'rest-client', :excon ]
+    REGISTERED_SPANS = [ :rack, :'net-http', :excon ]
 
     # @return [Integer] the ID for this trace
     attr_reader :id

--- a/test/instrumentation/rest-client_test.rb
+++ b/test/instrumentation/rest-client_test.rb
@@ -25,10 +25,10 @@ class RestClientTest < Minitest::Test
     third_span = spans[2]
 
     # Span name validation
-    assert_equal :sdk, first_span[:n]
-    assert_equal :"restclient-test", first_span[:data][:sdk][:name]
-    assert_equal :"rest-client", second_span[:n]
-    assert_equal :"net-http", third_span[:n]
+    assert first_span.custom?
+    assert_equal :"restclient-test", first_span.name
+    assert_equal :"rest-client", second_span.name
+    assert_equal :"net-http", third_span.name
 
     # first_span is the parent of second_span
     assert_equal first_span.id, second_span[:p]

--- a/test/tracing/tracer_async_test.rb
+++ b/test/tracing/tracer_async_test.rb
@@ -76,7 +76,7 @@ class TracerAsyncTest < Minitest::Test
 
     assert_equal false, ::Instana.tracer.tracing?
 
-    # Sleep for 2 seconds to wait for the async thread to finish
+    # Sleep for 1 seconds to wait for the async thread to finish
     sleep 1
 
     traces = ::Instana.processor.queued_traces


### PR DESCRIPTION
Instead of a registered span, report rest-client as an
sdk span.