### PR TITLE
Better state messages with default logging.

### DIFF
--- a/lib/instana/agent.rb
+++ b/lib/instana/agent.rb
@@ -129,7 +129,7 @@ module Instana
       # In case of failure, we try again in 30 seconds.
       @announce_timer = @timers.now_and_every(30) do
         if host_agent_ready? && announce_sensor
-          ::Instana.logger.debug "Announce successful. Switching to metrics collection."
+          ::Instana.logger.warn "Host agent available. We're in business."
           transition_to(:announced)
         end
       end
@@ -143,7 +143,7 @@ module Instana
             # If report has been failing for more than 1 minute,
             # fall back to unannounced state
             if (Time.now - @entity_last_seen) > 60
-              ::Instana.logger.debug "Metrics reporting failed for >1 min.  Falling back to unannounced state."
+              ::Instana.logger.warn "Host agent offline for >1 min.  Going to sit in a corner..."
               transition_to(:unannounced)
             end
           end

--- a/lib/instana/instrumentation/excon.rb
+++ b/lib/instana/instrumentation/excon.rb
@@ -58,7 +58,7 @@ if defined?(::Excon) && ::Instana.config[:excon][:enabled]
     end
   end
 
-  ::Instana.logger.warn "Instrumenting excon"
+  ::Instana.logger.warn "Instrumenting Excon"
   ::Excon.defaults[:middlewares].unshift(::Instana::Instrumentation::Excon)
 end
 

--- a/lib/instana/instrumentation/net-http.rb
+++ b/lib/instana/instrumentation/net-http.rb
@@ -43,7 +43,7 @@ Net::HTTP.class_eval {
     ::Instana.tracer.log_exit(:'net-http')
   end
 
-  Instana.logger.info "Instrumenting net/http"
+  Instana.logger.warn "Instrumenting Net::HTTP"
 
   alias request_without_instana request
   alias request request_with_instana


### PR DESCRIPTION
This normalizes the "instrumenting" messages and now outputs user friendly messages with the default log level in place.

This screenshot shows a successful boot of the stack and having the host agent go offline for a period.

<img width="848" alt="screen shot 2016-12-16 at 14 25 55" src="https://cloud.githubusercontent.com/assets/395132/21264305/e9c26074-c39b-11e6-8dc4-9f326c145923.png">
