### PR TITLE
Improved Error Handling & Reporting

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -12,6 +12,9 @@ engines:
     enabled: true
   rubocop:
     enabled: true
+    checks:
+      Rubocop/Metrics/CyclomaticComplexity:
+        enabled: false
 ratings:
   paths:
   - "**.inc"

--- a/lib/instana/instrumentation/excon.rb
+++ b/lib/instana/instrumentation/excon.rb
@@ -46,6 +46,12 @@ if defined?(::Excon) && ::Instana.config[:excon][:enabled]
             status = datum[:response][:status]
           end
 
+          if status.between?(500, 511)
+            # Because of the 5xx response, we flag this span as errored but
+            # without a backtrace (no exception)
+            ::Instana.tracer.log_error(nil)
+          end
+
           if datum[:pipeline] == true
             # Pickup context of this async span from datum[:instana_id]
             ::Instana.tracer.log_async_exit(:excon, { :http => {:status => status } }, datum[:instana_context])

--- a/lib/instana/instrumentation/rack.rb
+++ b/lib/instana/instrumentation/rack.rb
@@ -30,6 +30,12 @@ module Instana
       if ::Instana.tracer.tracing?
         kvs[:http][:status] = status
 
+        if status.between?(500, 511)
+          # Because of the 5xx response, we flag this span as errored but
+          # without a backtrace (no exception)
+          ::Instana.tracer.log_error(nil)
+        end
+
         # Save the IDs before the trace ends so we can place
         # them in the response headers in the ensure block
         trace_id = ::Instana.tracer.trace_id

--- a/lib/instana/logger.rb
+++ b/lib/instana/logger.rb
@@ -10,7 +10,7 @@ module Instana
         self.level = Logger::DEBUG
       elsif ENV.key?('INSTANA_GEM_DEV')
         self.level = Logger::DEBUG
-        self.debub_level = nil
+        self.debug_level = nil
       else
         self.level = Logger::WARN
       end

--- a/lib/instana/tracing/trace.rb
+++ b/lib/instana/tracing/trace.rb
@@ -159,7 +159,7 @@ module Instana
         end
 
         if HTTP_SPANS.include?(span.name)
-          add_info(:http => { :error => e.message })
+          add_info(:http => { :error => "#{e.class}: #{e.message}" })
         else
           add_info(:log => { :message => e.message, :parameters => e.class })
         end

--- a/lib/instana/tracing/trace.rb
+++ b/lib/instana/tracing/trace.rb
@@ -1,8 +1,9 @@
 module Instana
   class Trace
-    REGISTERED_SPANS = [ :rack, :'net-http', :excon ]
-    ENTRY_SPANS = [ :rack ]
-    EXIT_SPANS = [ :'net-http', :excon ]
+    REGISTERED_SPANS = [ :rack, :'net-http', :excon ].freeze
+    ENTRY_SPANS = [ :rack ].freeze
+    EXIT_SPANS = [ :'net-http', :excon ].freeze
+    HTTP_SPANS = ENTRY_SPANS + EXIT_SPANS
 
     # @return [Integer] the ID for this trace
     attr_reader :id
@@ -157,10 +158,11 @@ module Instana
           add_backtrace_to_span(e.backtrace, nil, span)
         end
 
-        add_info(:log => {
-          :message => e.message,
-          :parameters => e.class })
-
+        if HTTP_SPANS.include?(span.name)
+          add_info(:http => { :error => e.message })
+        else
+          add_info(:log => { :message => e.message, :parameters => e.class })
+        end
         e.instance_variable_set(:@instana_logged, true)
       end
 

--- a/lib/instana/util.rb
+++ b/lib/instana/util.rb
@@ -127,7 +127,7 @@ module Instana
         process[:name] = cmdline.shift
         process[:arguments] = cmdline
 
-        if @is_osx
+        if RUBY_PLATFORM =~ /darwin/i
           # Handle OSX bug where env vars show up at the end of process name
           # such as MANPATH etc..
           process[:name].gsub!(/[_A-Z]+=\S+/, '')

--- a/test/instrumentation/net-http_test.rb
+++ b/test/instrumentation/net-http_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class NetHTTPTest < Minitest::Test
-  def test_basic_get
+  def test_block_request
     ::Instana.processor.clear!
     WebMock.allow_net_connect!
     url = "http://127.0.0.1:6511/"
@@ -54,39 +54,81 @@ class NetHTTPTest < Minitest::Test
     WebMock.disable_net_connect!
   end
 
-  def test_request_with_error
+  def test_basic_post_without_uri
     ::Instana.processor.clear!
-    skip
     WebMock.allow_net_connect!
-    url = "http://doesnotresolve.asdfasdf"
 
-    uri = URI.parse(url)
-    req = Net::HTTP::Get.new(uri)
-
-    begin
-      response = nil
-      Instana.tracer.start_or_continue_trace('net-http-error-test') do
-        Net::HTTP.start(req.uri.hostname, req.uri.port, :open_timeout => 1, :read_timeout => 1) do |http|
-          response = http.request(req)
-        end
-      end
-    rescue
-      # We are raising an exception on purpose - do nothing
+    response = nil
+    Instana.tracer.start_or_continue_trace('net-http-test') do
+      http = Net::HTTP.new("127.0.0.1", 6511)
+      response = http.request(Net::HTTP::Post.new("/"))
     end
 
-    assert_equal 1, ::Instana.processor.queue_count
-    t = Instana.processor.queued_traces.first
-    assert_equal 2, t.spans.count
-    assert t.has_error?
-    spans = t.spans.to_a
+    assert_equal 2, ::Instana.processor.queue_count
+
+    traces = Instana.processor.queued_traces
+    rs_trace = traces[0]
+    http_trace = traces[1]
+
+    # Net::HTTP trace validation
+    assert_equal 2, http_trace.spans.count
+    spans = http_trace.spans.to_a
     first_span = spans[0]
     second_span = spans[1]
 
-    assert_equal 'net-http-test', first_span[:n]
+    # Span name validation
+    assert_equal :sdk, first_span[:n]
     assert_equal :'net-http', second_span[:n]
 
     # first_span is the parent of second_span
     assert_equal first_span.id, second_span[:p]
+
+    # data keys/values
+    refute_nil second_span.key?(:data)
+    refute_nil second_span[:data].key?(:http)
+    assert_equal "http://127.0.0.1:6511/", second_span[:data][:http][:url]
+    assert_equal "200", second_span[:data][:http][:status]
+    assert second_span.key?(:stack)
+
+    # Rack server trace validation
+    assert_equal 1, rs_trace.spans.count
+    rs_span = rs_trace.spans.to_a[0]
+
+    # Rack server trace should have the same trace ID
+    assert_equal http_trace.id, rs_span[:t].to_i
+    # Rack server trace should have net-http has parent span
+    assert_equal second_span.id, rs_span[:p].to_i
+
+    WebMock.disable_net_connect!
+  end
+
+  def test_request_with_dns_error
+    ::Instana.processor.clear!
+    WebMock.allow_net_connect!
+
+    begin
+      Instana.tracer.start_or_continue_trace('net-http-error-test') do
+        http = Net::HTTP.new("asdfasdf.asdfsadf", 80)
+        http.request(Net::HTTP::Get.new("/blah"))
+      end
+    rescue Exception
+      nil
+    end
+
+    traces = Instana.processor.queued_traces
+    assert_equal 1, traces.count
+    t = traces[0]
+    assert_equal 1, t.spans.count
+    assert t.has_error?
+    spans = t.spans.to_a
+    first_span = spans[0]
+
+    assert_equal :'net-http-error-test', first_span.name
+    assert first_span.custom?
+    assert first_span[:data][:sdk][:custom].key?(:log)
+    assert first_span[:data][:sdk][:custom][:log].key?(:message)
+    assert first_span[:data][:sdk][:custom][:log].key?(:parameters)
+
     WebMock.disable_net_connect!
   end
 end


### PR DESCRIPTION
This improves error logging, backtrace handling
and now marks HTTP client spans with 5xx response
codes as errored.