### PR TITLE
Add global enable/disable config options

### DIFF
--- a/Configuration.md
+++ b/Configuration.md
@@ -1,6 +1,24 @@
 # Configuration
 
-## Enabling/Disabling Components
+## Global Enable/Disable
+
+The entire gem can be disabled at runtime with:
+
+```Ruby
+::Instana.config[:enabled] = false # default: true
+```
+
+Other global enable/disable options are:
+
+```Ruby
+# Enable/Disable metrics collection and reporting
+Instana.config[:metrics][:enabled] # default true
+
+# Enable/Disable tracing
+Instana.config[:tracing][:enabled] # default true
+```
+
+## Enabling/Disabling Individual Components
 
 Individual components can be enabled and disabled with a local config.
 

--- a/lib/instana/collector.rb
+++ b/lib/instana/collector.rb
@@ -45,6 +45,8 @@ module Instana
     # @return Boolean true on success
     #
     def collect_and_report
+      return unless ::Instana.config[:metrics][:enabled]
+
       payload = {}
       with_snapshot = false
 

--- a/lib/instana/config.rb
+++ b/lib/instana/config.rb
@@ -3,12 +3,23 @@ module Instana
 
     def initialize
       @config = {}
+
       @config[:agent_host] = '127.0.0.1'
       @config[:agent_port] = 42699
-      @config[:metrics] = {}
+
+      # Global on/off switch for prebuilt environments
+      # Setting this to false will disable this gem
+      # from doing anything.
+      @config[:enabled] = true
+
+      # Enable/disable metrics globally or individually (default: all enabled)
+      @config[:metrics] = { :enabled => true }
       @config[:metrics][:gc]     = { :enabled => true }
       @config[:metrics][:memory] = { :enabled => true }
       @config[:metrics][:thread] = { :enabled => true }
+
+      # Enable/disable tracing (default: enabled)
+      @config[:tracing] = { :enabled => true }
 
       if ENV.key?('INSTANA_GEM_DEV')
         @config[:collector] = { :enabled => true, :interval => 3 }

--- a/lib/instana/config.rb
+++ b/lib/instana/config.rb
@@ -47,6 +47,13 @@ module Instana
 
     def []=(key, value)
       @config[key.to_sym] = value
+
+      if key == :enabled
+        # Configuring global enable/disable flag, then set the
+        # appropriate children flags.
+        @config[:metrics][:enabled] = value
+        @config[:tracing][:enabled] = value
+      end
     end
   end
 end

--- a/lib/instana/logger.rb
+++ b/lib/instana/logger.rb
@@ -6,6 +6,7 @@ module Instana
     STAMP = "Instana: ".freeze
 
     def initialize(*args)
+      super(*args)
       if ENV.key?('INSTANA_GEM_TEST')
         self.level = Logger::DEBUG
       elsif ENV.key?('INSTANA_GEM_DEV')
@@ -14,7 +15,6 @@ module Instana
       else
         self.level = Logger::WARN
       end
-      super(*args)
     end
 
     # Sets the debug level for this logger.  The debug level is broken up into various

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -18,4 +18,20 @@ class ConfigTest < Minitest::Test
       assert_equal true, ::Instana.config[:metrics][k].key?(:enabled)
     end
   end
+
+  def test_that_global_affects_children
+    # Disabling the gem should explicitly disable
+    # metrics and tracing flags
+    ::Instana.config[:enabled] = false
+
+    assert_equal false, ::Instana.config[:tracing][:enabled]
+    assert_equal false, ::Instana.config[:metrics][:enabled]
+
+    # Enabling the gem should explicitly enable
+    # metrics and tracing flags
+    ::Instana.config[:enabled] = true
+
+    assert_equal ::Instana.config[:tracing][:enabled]
+    assert_equal ::Instana.config[:metrics][:enabled]
+  end
 end

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -10,6 +10,10 @@ class ConfigTest < Minitest::Test
     assert_equal '127.0.0.1', ::Instana.config[:agent_host]
     assert_equal 42699, ::Instana.config[:agent_port]
 
+    assert ::Instana.config[:enabled]
+    assert ::Instana.config[:tracing][:enabled]
+    assert ::Instana.config[:metrics][:enabled]
+
     ::Instana.config[:metrics].each do |k, v|
       assert_equal true, ::Instana.config[:metrics][k].key?(:enabled)
     end

--- a/test/tracing/tracer_test.rb
+++ b/test/tracing/tracer_test.rb
@@ -6,6 +6,20 @@ class TracerTest < Minitest::Test
     assert ::Instana.tracer.is_a?(::Instana::Tracer)
   end
 
+  def test_obey_tracing_config
+    clear_all!
+
+    ::Instana.config[:tracing][:enabled] = false
+    assert_equal false, ::Instana.tracer.tracing?
+
+    ::Instana.tracer.start_or_continue_trace(:rack, {:one => 1}) do
+      assert_equal false, ::Instana.tracer.tracing?
+    end
+
+    ::Instana.config[:tracing][:enabled] = true
+  end
+
+
   def test_basic_trace_block
     clear_all!
 
@@ -13,7 +27,7 @@ class TracerTest < Minitest::Test
 
     ::Instana.tracer.start_or_continue_trace(:rack, {:one => 1}) do
       assert_equal true, ::Instana.tracer.tracing?
-      sleep 0.5
+      sleep 0.3
     end
 
     traces = ::Instana.processor.queued_traces


### PR DESCRIPTION
This PR adds the ability to enable/disable:

1. the entire gem globally (for prebuilt environments)
2. tracing
3. metrics

```
Instana.config[:enabled] # default true
Instana.config[:metrics][:enabled] # default true
Instana.config[:tracing][:enabled] # default true
```