### PR TITLE
Fix error logging of Net::HTTP 5xx responses

### DIFF
--- a/lib/instana/instrumentation/net-http.rb
+++ b/lib/instana/instrumentation/net-http.rb
@@ -46,7 +46,7 @@ if defined?(::Net::HTTP) && ::Instana.config[:nethttp][:enabled]
       if response.code.to_i.between?(500, 511)
         # Because of the 5xx response, we flag this span as errored but
         # without a backtrace (no exception)
-        add_error(nil)
+        ::Instana.tracer.log_error(nil)
       end
 
       response

--- a/test/servers/rackapp_6511.rb
+++ b/test/servers/rackapp_6511.rb
@@ -12,6 +12,11 @@ Thread.new do
         [200, {"Content-Type" => "application/json"}, ["[\"Stan\",\"is\",\"on\",\"the\",\"scene!\"]"]]
       }
     end
+    map "/error" do
+      run Proc.new { |env|
+        [500, {"Content-Type" => "application/json"}, ["[\"Stan\",\"is\",\"on\",\"the\",\"error!\"]"]]
+      }
+    end
   }
 
   Rack::Handler::Puma.run(app, {:Host => '127.0.0.1', :Port => 6511})


### PR DESCRIPTION
This fixes the error handling of 5xx responses with Net::HTP and
adds tests to validate.