### PR TITLE
Check existence of sched file before attempting to open.

### DIFF
--- a/lib/instana/agent.rb
+++ b/lib/instana/agent.rb
@@ -466,8 +466,15 @@ module Instana
     #
     def get_real_pid
       raise RuntimeError.new("Unsupported platform: get_real_pid") unless @is_linux
-      v = File.open("/proc/#{Process.pid}/sched", &:readline)
-      v.match(/\d+/).to_s.to_i
+
+      sched_file = "/proc/#{Process.pid}/sched"
+      pid = Process.pid
+
+      if File.exist?(sched_file)
+        v = File.open(sched_file, &:readline)
+        pid = v.match(/\d+/).to_s.to_i
+      end
+      pid
     end
 
     # Determine whether the pid has changed since Agent start.


### PR DESCRIPTION
Found on one of my ubuntu servers:
```
Instana: announce_sensor:agent.rb:193: No such file or directory @ rb_sysopen - /proc/26331/sched
```