### PR TITLE
Add support/mapping for OpenTracing span.kind

### DIFF
--- a/lib/instana/tracing/span.rb
+++ b/lib/instana/tracing/span.rb
@@ -271,6 +271,15 @@ module Instana
       if custom?
         @data[:data][:sdk][:custom] ||= {}
         @data[:data][:sdk][:custom][key] = value
+
+        if key.to_sym == :'span.kind'
+          case value.to_sym
+          when :server || :consumer
+            @data[:data][:sdk][:type] = :entry
+          when :client || :producer
+            @data[:data][:sdk][:type] = :exit
+          end
+        end
       else
         if !@data[:data].key?(key)
           @data[:data][key] = value


### PR DESCRIPTION
We should support mapping of `span.kind` to the Instana span SDK equivalent for proper translation.  Supported types are `server`, `producer`, `consumer` and `client`.