### PR TITLE
ActionView Span can show Unknown

### DIFF
--- a/lib/instana/frameworks/instrumentation/action_controller.rb
+++ b/lib/instana/frameworks/instrumentation/action_controller.rb
@@ -46,6 +46,10 @@ module Instana
         name ||= opts[:file]
         name = "Nothing" if opts[:nothing]
         name = "Plaintext" if opts[:plain]
+        name = "json" if opts[:json]
+        name = "XML" if opts[:xml]
+        name = "Raw" if opts[:body]
+        name = "Javascript" if opts[:js]
         name
       end
     end

--- a/lib/instana/frameworks/instrumentation/action_controller.rb
+++ b/lib/instana/frameworks/instrumentation/action_controller.rb
@@ -46,7 +46,7 @@ module Instana
         name ||= opts[:file]
         name = "Nothing" if opts[:nothing]
         name = "Plaintext" if opts[:plain]
-        name = "json" if opts[:json]
+        name = "JSON" if opts[:json]
         name = "XML" if opts[:xml]
         name = "Raw" if opts[:body]
         name = "Javascript" if opts[:js]

--- a/test/frameworks/rails/actionview3_test.rb
+++ b/test/frameworks/rails/actionview3_test.rb
@@ -69,6 +69,90 @@ class ActionViewTest < Minitest::Test
     assert_equal :actionview, third_span.name
   end
 
+  def test_render_json
+    clear_all!
+
+    Net::HTTP.get(URI.parse('http://localhost:3205/test/render_json'))
+
+    traces = Instana.processor.queued_traces
+    assert_equal 1, traces.count
+    trace = traces.first
+
+    assert_equal 3, trace.spans.count
+    spans = trace.spans.to_a
+    first_span = spans[0]
+    second_span = spans[1]
+    third_span = spans[2]
+
+    assert_equal :rack, first_span.name
+    assert_equal :actioncontroller, second_span.name
+    assert_equal "json", third_span[:data][:actionview][:name]
+    assert_equal :actionview, third_span.name
+  end
+
+  def test_render_xml
+    clear_all!
+
+    Net::HTTP.get(URI.parse('http://localhost:3205/test/render_xml'))
+
+    traces = Instana.processor.queued_traces
+    assert_equal 1, traces.count
+    trace = traces.first
+
+    assert_equal 3, trace.spans.count
+    spans = trace.spans.to_a
+    first_span = spans[0]
+    second_span = spans[1]
+    third_span = spans[2]
+
+    assert_equal :rack, first_span.name
+    assert_equal :actioncontroller, second_span.name
+    assert_equal "XML", third_span[:data][:actionview][:name]
+    assert_equal :actionview, third_span.name
+  end
+
+  def test_render_body
+    clear_all!
+
+    Net::HTTP.get(URI.parse('http://localhost:3205/test/render_rawbody'))
+
+    traces = Instana.processor.queued_traces
+    assert_equal 1, traces.count
+    trace = traces.first
+
+    assert_equal 3, trace.spans.count
+    spans = trace.spans.to_a
+    first_span = spans[0]
+    second_span = spans[1]
+    third_span = spans[2]
+
+    assert_equal :rack, first_span.name
+    assert_equal :actioncontroller, second_span.name
+    assert_equal "Raw", third_span[:data][:actionview][:name]
+    assert_equal :actionview, third_span.name
+  end
+
+  def test_render_js
+    clear_all!
+
+    Net::HTTP.get(URI.parse('http://localhost:3205/test/render_js'))
+
+    traces = Instana.processor.queued_traces
+    assert_equal 1, traces.count
+    trace = traces.first
+
+    assert_equal 3, trace.spans.count
+    spans = trace.spans.to_a
+    first_span = spans[0]
+    second_span = spans[1]
+    third_span = spans[2]
+
+    assert_equal :rack, first_span.name
+    assert_equal :actioncontroller, second_span.name
+    assert_equal "Javascript", third_span[:data][:actionview][:name]
+    assert_equal :actionview, third_span.name
+  end
+
   def test_render_alternate_layout
     clear_all!
 

--- a/test/frameworks/rails/actionview3_test.rb
+++ b/test/frameworks/rails/actionview3_test.rb
@@ -86,7 +86,7 @@ class ActionViewTest < Minitest::Test
 
     assert_equal :rack, first_span.name
     assert_equal :actioncontroller, second_span.name
-    assert_equal "json", third_span[:data][:actionview][:name]
+    assert_equal "JSON", third_span[:data][:actionview][:name]
     assert_equal :actionview, third_span.name
   end
 

--- a/test/frameworks/rails/actionview3_test.rb
+++ b/test/frameworks/rails/actionview3_test.rb
@@ -27,6 +27,69 @@ class ActionViewTest < Minitest::Test
     assert_equal :actionview, third_span.name
   end
 
+  def test_render_nothing
+    clear_all!
+
+    Net::HTTP.get(URI.parse('http://localhost:3205/test/render_nothing'))
+
+    traces = Instana.processor.queued_traces
+    assert_equal 1, traces.count
+    trace = traces.first
+
+    assert_equal 3, trace.spans.count
+    spans = trace.spans.to_a
+    first_span = spans[0]
+    second_span = spans[1]
+    third_span = spans[2]
+
+    assert_equal :rack, first_span.name
+    assert_equal :actioncontroller, second_span.name
+    assert_equal "Nothing", third_span[:data][:actionview][:name]
+    assert_equal :actionview, third_span.name
+  end
+
+  def test_render_file
+    clear_all!
+
+    Net::HTTP.get(URI.parse('http://localhost:3205/test/render_file'))
+
+    traces = Instana.processor.queued_traces
+    assert_equal 1, traces.count
+    trace = traces.first
+
+    assert_equal 3, trace.spans.count
+    spans = trace.spans.to_a
+    first_span = spans[0]
+    second_span = spans[1]
+    third_span = spans[2]
+
+    assert_equal :rack, first_span.name
+    assert_equal :actioncontroller, second_span.name
+    assert_equal "/etc/issue", third_span[:data][:actionview][:name]
+    assert_equal :actionview, third_span.name
+  end
+
+  def test_render_alternate_layout
+    clear_all!
+
+    Net::HTTP.get(URI.parse('http://localhost:3205/test/render_alternate_layout'))
+
+    traces = Instana.processor.queued_traces
+    assert_equal 1, traces.count
+    trace = traces.first
+
+    assert_equal 3, trace.spans.count
+    spans = trace.spans.to_a
+    first_span = spans[0]
+    second_span = spans[1]
+    third_span = spans[2]
+
+    assert_equal :rack, first_span.name
+    assert_equal :actioncontroller, second_span.name
+    assert_equal "layouts/mobile", third_span[:data][:actionview][:name]
+    assert_equal :actionview, third_span.name
+  end
+
   def test_render_partial
     clear_all!
 
@@ -106,4 +169,3 @@ class ActionViewTest < Minitest::Test
     assert_equal 'blocks/block', fifth_span[:data][:render][:name]
   end
 end
-

--- a/test/frameworks/rails/actionview4_test.rb
+++ b/test/frameworks/rails/actionview4_test.rb
@@ -69,6 +69,90 @@ class ActionViewTest < Minitest::Test
     assert_equal :actionview, third_span.name
   end
 
+  def test_render_json
+    clear_all!
+
+    Net::HTTP.get(URI.parse('http://localhost:3205/test/render_json'))
+
+    traces = Instana.processor.queued_traces
+    assert_equal 1, traces.count
+    trace = traces.first
+
+    assert_equal 3, trace.spans.count
+    spans = trace.spans.to_a
+    first_span = spans[0]
+    second_span = spans[1]
+    third_span = spans[2]
+
+    assert_equal :rack, first_span.name
+    assert_equal :actioncontroller, second_span.name
+    assert_equal "json", third_span[:data][:actionview][:name]
+    assert_equal :actionview, third_span.name
+  end
+
+  def test_render_xml
+    clear_all!
+
+    Net::HTTP.get(URI.parse('http://localhost:3205/test/render_xml'))
+
+    traces = Instana.processor.queued_traces
+    assert_equal 1, traces.count
+    trace = traces.first
+
+    assert_equal 3, trace.spans.count
+    spans = trace.spans.to_a
+    first_span = spans[0]
+    second_span = spans[1]
+    third_span = spans[2]
+
+    assert_equal :rack, first_span.name
+    assert_equal :actioncontroller, second_span.name
+    assert_equal "XML", third_span[:data][:actionview][:name]
+    assert_equal :actionview, third_span.name
+  end
+
+  def test_render_body
+    clear_all!
+
+    Net::HTTP.get(URI.parse('http://localhost:3205/test/render_rawbody'))
+
+    traces = Instana.processor.queued_traces
+    assert_equal 1, traces.count
+    trace = traces.first
+
+    assert_equal 3, trace.spans.count
+    spans = trace.spans.to_a
+    first_span = spans[0]
+    second_span = spans[1]
+    third_span = spans[2]
+
+    assert_equal :rack, first_span.name
+    assert_equal :actioncontroller, second_span.name
+    assert_equal "Raw", third_span[:data][:actionview][:name]
+    assert_equal :actionview, third_span.name
+  end
+
+  def test_render_js
+    clear_all!
+
+    Net::HTTP.get(URI.parse('http://localhost:3205/test/render_js'))
+
+    traces = Instana.processor.queued_traces
+    assert_equal 1, traces.count
+    trace = traces.first
+
+    assert_equal 3, trace.spans.count
+    spans = trace.spans.to_a
+    first_span = spans[0]
+    second_span = spans[1]
+    third_span = spans[2]
+
+    assert_equal :rack, first_span.name
+    assert_equal :actioncontroller, second_span.name
+    assert_equal "Javascript", third_span[:data][:actionview][:name]
+    assert_equal :actionview, third_span.name
+  end
+
   def test_render_alternate_layout
     clear_all!
 

--- a/test/frameworks/rails/actionview4_test.rb
+++ b/test/frameworks/rails/actionview4_test.rb
@@ -27,6 +27,69 @@ class ActionViewTest < Minitest::Test
     assert_equal :actionview, third_span.name
   end
 
+  def test_render_nothing
+    clear_all!
+
+    Net::HTTP.get(URI.parse('http://localhost:3205/test/render_nothing'))
+
+    traces = Instana.processor.queued_traces
+    assert_equal 1, traces.count
+    trace = traces.first
+
+    assert_equal 3, trace.spans.count
+    spans = trace.spans.to_a
+    first_span = spans[0]
+    second_span = spans[1]
+    third_span = spans[2]
+
+    assert_equal :rack, first_span.name
+    assert_equal :actioncontroller, second_span.name
+    assert_equal "Nothing", third_span[:data][:actionview][:name]
+    assert_equal :actionview, third_span.name
+  end
+
+  def test_render_file
+    clear_all!
+
+    Net::HTTP.get(URI.parse('http://localhost:3205/test/render_file'))
+
+    traces = Instana.processor.queued_traces
+    assert_equal 1, traces.count
+    trace = traces.first
+
+    assert_equal 3, trace.spans.count
+    spans = trace.spans.to_a
+    first_span = spans[0]
+    second_span = spans[1]
+    third_span = spans[2]
+
+    assert_equal :rack, first_span.name
+    assert_equal :actioncontroller, second_span.name
+    assert_equal "/etc/issue", third_span[:data][:actionview][:name]
+    assert_equal :actionview, third_span.name
+  end
+
+  def test_render_alternate_layout
+    clear_all!
+
+    Net::HTTP.get(URI.parse('http://localhost:3205/test/render_alternate_layout'))
+
+    traces = Instana.processor.queued_traces
+    assert_equal 1, traces.count
+    trace = traces.first
+
+    assert_equal 3, trace.spans.count
+    spans = trace.spans.to_a
+    first_span = spans[0]
+    second_span = spans[1]
+    third_span = spans[2]
+
+    assert_equal :rack, first_span.name
+    assert_equal :actioncontroller, second_span.name
+    assert_equal "layouts/mobile", third_span[:data][:actionview][:name]
+    assert_equal :actionview, third_span.name
+  end
+
   def test_render_partial
     clear_all!
 
@@ -105,4 +168,3 @@ class ActionViewTest < Minitest::Test
     assert_equal 'blocks/block', fifth_span[:data][:render][:name]
   end
 end
-

--- a/test/frameworks/rails/actionview4_test.rb
+++ b/test/frameworks/rails/actionview4_test.rb
@@ -86,7 +86,7 @@ class ActionViewTest < Minitest::Test
 
     assert_equal :rack, first_span.name
     assert_equal :actioncontroller, second_span.name
-    assert_equal "json", third_span[:data][:actionview][:name]
+    assert_equal "JSON", third_span[:data][:actionview][:name]
     assert_equal :actionview, third_span.name
   end
 

--- a/test/frameworks/rails/actionview5_test.rb
+++ b/test/frameworks/rails/actionview5_test.rb
@@ -69,6 +69,90 @@ class ActionViewTest < Minitest::Test
     assert_equal :actionview, third_span.name
   end
 
+  def test_render_json
+    clear_all!
+
+    Net::HTTP.get(URI.parse('http://localhost:3205/test/render_json'))
+
+    traces = Instana.processor.queued_traces
+    assert_equal 1, traces.count
+    trace = traces.first
+
+    assert_equal 3, trace.spans.count
+    spans = trace.spans.to_a
+    first_span = spans[0]
+    second_span = spans[1]
+    third_span = spans[2]
+
+    assert_equal :rack, first_span.name
+    assert_equal :actioncontroller, second_span.name
+    assert_equal "json", third_span[:data][:actionview][:name]
+    assert_equal :actionview, third_span.name
+  end
+
+  def test_render_xml
+    clear_all!
+
+    Net::HTTP.get(URI.parse('http://localhost:3205/test/render_xml'))
+
+    traces = Instana.processor.queued_traces
+    assert_equal 1, traces.count
+    trace = traces.first
+
+    assert_equal 3, trace.spans.count
+    spans = trace.spans.to_a
+    first_span = spans[0]
+    second_span = spans[1]
+    third_span = spans[2]
+
+    assert_equal :rack, first_span.name
+    assert_equal :actioncontroller, second_span.name
+    assert_equal "XML", third_span[:data][:actionview][:name]
+    assert_equal :actionview, third_span.name
+  end
+
+  def test_render_body
+    clear_all!
+
+    Net::HTTP.get(URI.parse('http://localhost:3205/test/render_rawbody'))
+
+    traces = Instana.processor.queued_traces
+    assert_equal 1, traces.count
+    trace = traces.first
+
+    assert_equal 3, trace.spans.count
+    spans = trace.spans.to_a
+    first_span = spans[0]
+    second_span = spans[1]
+    third_span = spans[2]
+
+    assert_equal :rack, first_span.name
+    assert_equal :actioncontroller, second_span.name
+    assert_equal "Raw", third_span[:data][:actionview][:name]
+    assert_equal :actionview, third_span.name
+  end
+
+  def test_render_js
+    clear_all!
+
+    Net::HTTP.get(URI.parse('http://localhost:3205/test/render_js'))
+
+    traces = Instana.processor.queued_traces
+    assert_equal 1, traces.count
+    trace = traces.first
+
+    assert_equal 3, trace.spans.count
+    spans = trace.spans.to_a
+    first_span = spans[0]
+    second_span = spans[1]
+    third_span = spans[2]
+
+    assert_equal :rack, first_span.name
+    assert_equal :actioncontroller, second_span.name
+    assert_equal "Javascript", third_span[:data][:actionview][:name]
+    assert_equal :actionview, third_span.name
+  end
+
   def test_render_alternate_layout
     clear_all!
 

--- a/test/frameworks/rails/actionview5_test.rb
+++ b/test/frameworks/rails/actionview5_test.rb
@@ -27,6 +27,69 @@ class ActionViewTest < Minitest::Test
     assert_equal :actionview, third_span.name
   end
 
+  def test_render_nothing
+    clear_all!
+
+    Net::HTTP.get(URI.parse('http://localhost:3205/test/render_nothing'))
+
+    traces = Instana.processor.queued_traces
+    assert_equal 1, traces.count
+    trace = traces.first
+
+    assert_equal 3, trace.spans.count
+    spans = trace.spans.to_a
+    first_span = spans[0]
+    second_span = spans[1]
+    third_span = spans[2]
+
+    assert_equal :rack, first_span.name
+    assert_equal :actioncontroller, second_span.name
+    assert_equal "Nothing", third_span[:data][:actionview][:name]
+    assert_equal :actionview, third_span.name
+  end
+
+  def test_render_file
+    clear_all!
+
+    Net::HTTP.get(URI.parse('http://localhost:3205/test/render_file'))
+
+    traces = Instana.processor.queued_traces
+    assert_equal 1, traces.count
+    trace = traces.first
+
+    assert_equal 3, trace.spans.count
+    spans = trace.spans.to_a
+    first_span = spans[0]
+    second_span = spans[1]
+    third_span = spans[2]
+
+    assert_equal :rack, first_span.name
+    assert_equal :actioncontroller, second_span.name
+    assert_equal "/etc/issue", third_span[:data][:actionview][:name]
+    assert_equal :actionview, third_span.name
+  end
+
+  def test_render_alternate_layout
+    clear_all!
+
+    Net::HTTP.get(URI.parse('http://localhost:3205/test/render_alternate_layout'))
+
+    traces = Instana.processor.queued_traces
+    assert_equal 1, traces.count
+    trace = traces.first
+
+    assert_equal 3, trace.spans.count
+    spans = trace.spans.to_a
+    first_span = spans[0]
+    second_span = spans[1]
+    third_span = spans[2]
+
+    assert_equal :rack, first_span.name
+    assert_equal :actioncontroller, second_span.name
+    assert_equal "layouts/mobile", third_span[:data][:actionview][:name]
+    assert_equal :actionview, third_span.name
+  end
+
   def test_render_partial
     clear_all!
 
@@ -113,4 +176,3 @@ class ActionViewTest < Minitest::Test
     assert_equal 'blocks/block', fifth_span[:data][:render][:name]
   end
 end
-

--- a/test/frameworks/rails/actionview5_test.rb
+++ b/test/frameworks/rails/actionview5_test.rb
@@ -86,7 +86,7 @@ class ActionViewTest < Minitest::Test
 
     assert_equal :rack, first_span.name
     assert_equal :actioncontroller, second_span.name
-    assert_equal "json", third_span[:data][:actionview][:name]
+    assert_equal "JSON", third_span[:data][:actionview][:name]
     assert_equal :actionview, third_span.name
   end
 

--- a/test/servers/rails_3205.rb
+++ b/test/servers/rails_3205.rb
@@ -30,6 +30,10 @@ class RailsTestApp < Rails::Application
     get "/test/render_collection"  => "test#render_collection"
     get "/test/render_file"        => "test#render_file"
     get "/test/render_nothing"     => "test#render_nothing"
+    get "/test/render_json"        => "test#render_json"
+    get "/test/render_xml"         => "test#render_xml"
+    get "/test/render_rawbody"     => "test#render_rawbody"
+    get "/test/render_js"          => "test#render_js"
     get "/test/render_alternate_layout"        => "test#render_alternate_layout"
     get "/test/render_partial_that_errors"     => "test#render_partial_that_errors"
 
@@ -107,6 +111,26 @@ class TestController < ActionController::Base
   def render_nothing
     @message = "Hello Instana!"
     render :nothing => true
+  end
+
+  def render_json
+    @message = "Hello Instana!"
+    render :json => @message
+  end
+
+  def render_xml
+    @message = "Hello Instana!"
+    render :xml => @message
+  end
+
+  def render_rawbody
+    @message = "Hello Instana!"
+    render :body => 'raw body output'
+  end
+
+  def render_js
+    @message = "Hello Instana!"
+    render :js => @message
   end
 
   def error

--- a/test/servers/rails_3205.rb
+++ b/test/servers/rails_3205.rb
@@ -27,8 +27,11 @@ class RailsTestApp < Rails::Application
     get "/test/error"              => "test#error"
     get "/test/render_view"        => "test#render_view"
     get "/test/render_partial"     => "test#render_partial"
-    get "/test/render_partial_that_errors"     => "test#render_partial_that_errors"
     get "/test/render_collection"  => "test#render_collection"
+    get "/test/render_file"        => "test#render_file"
+    get "/test/render_nothing"     => "test#render_nothing"
+    get "/test/render_alternate_layout"        => "test#render_alternate_layout"
+    get "/test/render_partial_that_errors"     => "test#render_partial_that_errors"
 
     get "/api/world" => "socket#world"
     get "/api/error" => "socket#error"
@@ -89,6 +92,21 @@ class TestController < ActionController::Base
 
   def render_collection
     @blocks = Block.all
+  end
+
+  def render_file
+    @message = "Hello Instana!"
+    render :file => '/etc/issue'
+  end
+
+  def render_alternate_layout
+    @message = "Hello Instana!"
+    render :layout => 'layouts/mobile'
+  end
+
+  def render_nothing
+    @message = "Hello Instana!"
+    render :nothing => true
   end
 
   def error


### PR DESCRIPTION
When rendering a _default_ view, there may not be a partial or layout name available to the sensor (or is there?).  In any case, showing "unknown" could be impoved upon.

![screen shot 2017-04-03 at 12 33 44](https://cloud.githubusercontent.com/assets/395132/24605616/d0428160-1869-11e7-917d-dfec2b02b0fa.png)

Still to do - add support for:
- [x] json
- [x] xml
- [x] body/raw
- [x] js
