### PR TITLE
OSX development environment with Spring/Puma causes failed announce

### DIFF
--- a/lib/instana/agent.rb
+++ b/lib/instana/agent.rb
@@ -44,6 +44,10 @@ module Instana
         @default_gateway = nil
       end
 
+      # Collect initial process info - repeat prior to announce
+      # in `announce_sensor` in case of process rename, after fork etc.
+      @process = ::Instana::Util.collect_process_info
+
       # The agent UUID returned from the host agent
       @agent_uuid = nil
 


### PR DESCRIPTION
In OSX development environments, either spring or puma is rewriting the process command line name which causes the agent to fail to announce.

Other processes announce fine (Linux, OSX Ruby console, OSX other stacks).

The screenshot below shows the rewritten command line (in the bottom window) and what the Ruby process thinks (top window).

<img width="1790" alt="ruby dev env spring puma failed announce 2017-05-04 at 12 08 21" src="https://cloud.githubusercontent.com/assets/395132/25699337/1f10aca6-30c3-11e7-94ba-921b8c1a0d2c.png">
