### PR TITLE
Header values with leading zeros can be incorrectly converted

### DIFF
--- a/lib/instana/tracer.rb
+++ b/lib/instana/tracer.rb
@@ -393,7 +393,7 @@ module Instana
     # Indicates if the name of the current span matches <candidate>
     #
     def current_span_name?(candidate)
-      self.current_trace &&  self.current_trace.current_span.name == candidate
+      self.current_trace &&  self.current_trace.current_span.name == candidate.to_sym
     end
 
     # Used in the test suite, this resets the tracer to non-tracing state.

--- a/lib/instana/util.rb
+++ b/lib/instana/util.rb
@@ -211,7 +211,8 @@ module Instana
         if header_id.length < 16
           # The header is less than 16 chars.  Prepend
           # zeros so we can convert correctly
-          header_id = "%016d" % header_id
+          missing = 16 - header_id.length
+          header_id = ("0" * missing) + header_id
         end
         [header_id].pack("H*").unpack("q>")[0]
       rescue => e

--- a/lib/instana/util.rb
+++ b/lib/instana/util.rb
@@ -191,7 +191,7 @@ module Instana
           Instana.logger.debug "id_to_header received a #{id.class}: returning empty string"
           return String.new
         end
-        [id.to_i].pack('q>').unpack('H*')[0]
+        [id.to_i].pack('q>').unpack('H*')[0].gsub(/^0+/, '')
       rescue => e
         Instana.logger.error "#{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}"
         Instana.logger.debug e.backtrace.join("\r\n")
@@ -207,6 +207,11 @@ module Instana
         if !header_id.is_a?(String)
           Instana.logger.debug "header_to_id received a #{header_id.class}: returning 0"
           return 0
+        end
+        if header_id.length < 16
+          # The header is less than 16 chars.  Prepend
+          # zeros so we can convert correctly
+          header_id = "%016d" % header_id
         end
         [header_id].pack("H*").unpack("q>")[0]
       rescue => e

--- a/test/tracing/id_management_test.rb
+++ b/test/tracing/id_management_test.rb
@@ -88,6 +88,13 @@ class TracerIDMgmtTest < Minitest::Test
 
     result = Instana::Util.id_to_header(id)
     assert_equal header, result
+
+    10000.times do
+      original_id = ::Instana::Util.generate_id
+      header_id = Instana::Util.id_to_header(original_id)
+      converted_back_id = Instana::Util.header_to_id(header_id)
+      assert original_id == converted_back_id
+    end
   end
 
   def test_id_max_value_and_conversion

--- a/test/tracing/id_management_test.rb
+++ b/test/tracing/id_management_test.rb
@@ -113,5 +113,11 @@ class TracerIDMgmtTest < Minitest::Test
 
     id = ::Instana::Util.header_to_id("0000000000000010")
     assert_equal 16, id
+
+    id = ::Instana::Util.header_to_id("88b6c735206ca42")
+    assert_equal 615705016619420226, id
+
+    id = ::Instana::Util.header_to_id("088b6c735206ca42")
+    assert_equal 615705016619420226, id
   end
 end

--- a/test/tracing/id_management_test.rb
+++ b/test/tracing/id_management_test.rb
@@ -26,7 +26,7 @@ class TracerIDMgmtTest < Minitest::Test
 
     # Assert that it is a string and there are no non-hex characters
     assert converted_id.is_a?(String)
-    assert converted_id == "0000000000000000"
+    assert converted_id == ''
 
     # Test passing a nil
     converted_id = Instana::Util.id_to_header(nil)
@@ -101,5 +101,17 @@ class TracerIDMgmtTest < Minitest::Test
 
     assert_equal max_id, Instana::Util.header_to_id(max_hex)
     assert_equal min_id, Instana::Util.header_to_id(min_hex)
+  end
+
+  def test_that_leading_zeros_handled_correctly
+
+    header = ::Instana::Util.id_to_header(16)
+    assert_equal "10", header
+
+    id = ::Instana::Util.header_to_id("10")
+    assert_equal 16, id
+
+    id = ::Instana::Util.header_to_id("0000000000000010")
+    assert_equal 16, id
   end
 end


### PR DESCRIPTION
<img width="475" alt="screen shot 2017-05-19 at 13 25 29" src="https://cloud.githubusercontent.com/assets/395132/26245923/da12372a-3c96-11e7-9fc8-c694baf6d8c2.png">

It's likely that the Ruby conversion requires a 16 char string.  When leading zeros are dropped by any other language this ruby sensor won't convert into the correct value.

We should prepend any header values with zeros if length < 16 prior to converting.