### PR TITLE
ActiveRecord: Accessing adapter name triggers DB connection

### DIFF
--- a/lib/instana/frameworks/instrumentation/active_record.rb
+++ b/lib/instana/frameworks/instrumentation/active_record.rb
@@ -5,17 +5,23 @@ require "instana/frameworks/instrumentation/mysql2_adapter"
 require "instana/frameworks/instrumentation/postgresql_adapter"
 
 if defined?(::ActiveRecord) && ::Instana.config[:active_record][:enabled]
-  case ActiveRecord::Base.connection.adapter_name.downcase
-  when 'mysql'
+
+  # Mysql
+  if defined?(ActiveRecord::ConnectionAdapters::MysqlAdapter)
     ::Instana.logger.warn "Instrumenting ActiveRecord (mysql)"
     ActiveRecord::ConnectionAdapters::MysqlAdapter.send(:include, ::Instana::Instrumentation::MysqlAdapter)
     ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter.send(:include, ::Instana::Instrumentation::AbstractMysqlAdapter)
-  when 'mysql2'
+
+  # Mysql2
+  elsif defined?(ActiveRecord::ConnectionAdapters::Mysql2Adapter)
     ::Instana.logger.warn "Instrumenting ActiveRecord (mysql2)"
     ActiveRecord::ConnectionAdapters::Mysql2Adapter.send(:include, ::Instana::Instrumentation::Mysql2Adapter)
-  when 'postgresql'
+
+  # Postgres
+  elsif defined?(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter)
     ::Instana.logger.warn "Instrumenting ActiveRecord (postgresql)"
     ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.send(:include, ::Instana::Instrumentation::PostgreSQLAdapter)
+
   else
     ::Instana.logger.warn "Unsupported ActiveRecord adapter: #{ActiveRecord::Base.connection.adapter_name.downcase}"
   end


### PR DESCRIPTION
Just by accessing `connection` it resolves eventually to `new_connection` which is undesired in case we are running outside of the intended environment (such as building a docker image or running rake tasks).

We should avoid accessing `ActiveRecord::Base.connection.adapter_name` here:
https://github.com/instana/ruby-sensor/blob/master/lib/instana/frameworks/instrumentation/active_record.rb#L8