### PR TITLE
OSX: Process announce can sometimes fail because of sys-proctable

### DIFF
--- a/lib/instana/agent.rb
+++ b/lib/instana/agent.rb
@@ -1,10 +1,8 @@
 require 'json'
 require 'net/http'
 require 'socket'
-require 'sys/proctable'
 require 'timers'
 require 'uri'
-include Sys
 
 module Instana
   class Agent

--- a/lib/instana/util.rb
+++ b/lib/instana/util.rb
@@ -1,3 +1,6 @@
+require 'sys/proctable'
+include Sys
+
 module Instana
   module Util
     class << self
@@ -131,21 +134,25 @@ module Instana
         process = {}
         cmdline_file = "/proc/#{Process.pid}/cmdline"
 
-        # If there is a /proc filesystem, we read this manually so
-        # we can split on embedded null bytes.  Otherwise (e.g. OSX, Windows)
-        # use ProcTable.
-        if File.exist?(cmdline_file)
-          cmdline = IO.read(cmdline_file).split(?\x00)
-        else
-          cmdline = ProcTable.ps(Process.pid).cmdline.split(' ')
-        end
+        ptable = ProcTable.ps(Process.pid)
 
-        if RUBY_PLATFORM =~ /darwin/i
-          cmdline.delete_if{ |e| e.include?('=') }
-          process[:name] = cmdline.join(' ')
+        if RUBY_PLATFORM =~ /darwin/i ||
+          RUBY_PLATFORM =~ /linux/i
+          # SysProctable supports OSX, Linux well
+          process[:name] = ptable.pname
+          process[:arguments] = ptable.arguments
         else
-          process[:name] = cmdline.shift
-          process[:arguments] = cmdline
+          # Some other platform - try using /proc first
+          if File.exist?(cmdline_file)
+            cmdline = IO.read(cmdline_file).split(?\x00)
+            process[:name] = cmdline.shift
+            process[:arguments] = cmdline
+          else
+            # Last ditch effort
+            parts = ptable.cmdline.split(' ')
+            process[:name] = parts.shift
+            process[:arguments] = parts
+          end
         end
 
         process[:pid] = Process.pid


### PR DESCRIPTION
On OSX, we use sys-proctable to read the process table.  Unfortunately, this lib parses and reconstructs the raw command line which makes it hard for us to correctly identify where process name ends and arguments start.  (Hint: it's sometimes more than just whitespace)

https://github.com/djberg96/sys-proctable/blob/master/lib/darwin/sys/proctable.rb#L333

This can lead to a failed announce when the host agent is looking for specifics (name == name and arguments == arguments).