### PR TITLE
log_info/add_info should properly translate span.kind

### DIFF
--- a/lib/instana/tracing/span.rb
+++ b/lib/instana/tracing/span.rb
@@ -107,19 +107,6 @@ module Instana
     def configure_custom(name)
       @data[:n] = :sdk
       @data[:data] = { :sdk => { :name => name.to_sym } }
-
-      #if kvs.is_a?(Hash)
-      #  @data[:data][:sdk][:type] = kvs.key?(:type) ? kvs[:type] : :local
-#
-#        if kvs.key?(:arguments)
-#          @data[:data][:sdk][:arguments] = kvs[:arguments]
-#        end
-#
-#        if kvs.key?(:return)
-#          @data[:data][:sdk][:return] = kvs[:return]
-#        end
-#        @data[:data][:sdk][:custom] = kvs unless kvs.empty?
-#      end
       self
     end
 

--- a/lib/instana/tracing/trace.rb
+++ b/lib/instana/tracing/trace.rb
@@ -82,23 +82,9 @@ module Instana
     def add_info(kvs, span = nil)
       span ||= @current_span
 
-      if span.custom?
-        if span[:data][:sdk].key?(:custom)
-          span[:data][:sdk][:custom].merge!(kvs)
-        else
-          span[:data][:sdk][:custom] = kvs
-        end
-      else
-        kvs.each_pair do |k,v|
-          if !span[:data].key?(k)
-            span[:data][k] = v
-          elsif v.is_a?(Hash) && span[:data][k].is_a?(Hash)
-            span[:data][k].merge!(v)
-          else
-            span[:data][k] = v
-          end
-        end
-      end
+      # Pass on to the OT span interface which will properly
+      # apply KVs based on span type
+      span.set_tags(kvs)
     end
 
     # Log an error into the current span


### PR DESCRIPTION
Similar to what OT [set_tag](https://github.com/instana/ruby-sensor/blob/master/lib/instana/tracing/span.rb#L275) does, [add_info](https://github.com/instana/ruby-sensor/blob/master/lib/instana/tracing/trace.rb#L82) should also support the proper translation when `span.kind` is set.

