### PR TITLE
GRPC instrumentation implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@
 /pkg/
 /spec/reports/
 /tmp/
+/log/
 .ruby-version
 gemfiles/*.lock

--- a/gemfiles/libraries.gemfile
+++ b/gemfiles/libraries.gemfile
@@ -27,6 +27,9 @@ gem "sinatra", '1.4.7'
 gem "cuba"
 gem "roda"
 
+# gRPC
+gem 'grpc'
+
 # HTTP Clients
 gem 'rest-client'
 

--- a/lib/instana/config.rb
+++ b/lib/instana/config.rb
@@ -39,7 +39,7 @@ module Instana
       @config[:excon]              = { :enabled => true }
       @config[:nethttp]            = { :enabled => true }
       @config[:'rest-client']      = { :enabled => true }
-      @config[:'grpc']             = { :enabled => true }
+      @config[:grpc]               = { :enabled => true }
     end
 
     def [](key)

--- a/lib/instana/config.rb
+++ b/lib/instana/config.rb
@@ -39,6 +39,7 @@ module Instana
       @config[:excon]              = { :enabled => true }
       @config[:nethttp]            = { :enabled => true }
       @config[:'rest-client']      = { :enabled => true }
+      @config[:'grpc']             = { :enabled => true }
     end
 
     def [](key)

--- a/lib/instana/instrumentation/grpc.rb
+++ b/lib/instana/instrumentation/grpc.rb
@@ -1,6 +1,6 @@
 call_types = [:request_response, :client_streamer, :server_streamer, :bidi_streamer]
 
-if defined?(GRPC::ActiveCall) && ::Instana.config[:'grpc'][:enabled]
+if defined?(GRPC::ActiveCall) && ::Instana.config[:grpc][:enabled]
   call_types.each do |call_type|
     GRPC::ClientStub.class_eval <<-RUBY, __FILE__, __LINE__ + 1
       def #{call_type}_with_instana(method, *others, **options)
@@ -42,7 +42,7 @@ if defined?(GRPC::ActiveCall) && ::Instana.config[:'grpc'][:enabled]
   ::Instana.logger.warn 'Instrumenting GRPC client'
 end
 
-if defined?(GRPC::RpcDesc) && ::Instana.config[:'grpc'][:enabled]
+if defined?(GRPC::RpcDesc) && ::Instana.config[:grpc][:enabled]
   call_types.each do |call_type|
     GRPC::RpcDesc.class_eval <<-RUBY, __FILE__, __LINE__ + 1
       def handle_#{call_type}_with_instana(active_call, mth)

--- a/lib/instana/instrumentation/grpc.rb
+++ b/lib/instana/instrumentation/grpc.rb
@@ -1,0 +1,72 @@
+if defined?(GRPC::ActiveCall)
+  GRPC::ClientStub.class_eval do
+    def request_response_with_instana(method, *others, **options)
+      unless ::Instana.tracer.tracing?
+        return request_response_without_instana(method, *others, **options)
+      end
+
+      ::Instana.tracer.log_entry(:'net-http')
+      kv_payload = { http: {} }
+      kv_payload[:http][:method] = 'GRPC'
+      kv_payload[:http][:host] = @host
+      kv_payload[:http][:url] = method
+
+      context = ::Instana.tracer.context
+      if context
+        options[:metadata] = (options[:metadata] || {}).merge(
+          'x-instana-t' => context.trace_id_header,
+          'x-instana-s' => context.span_id_header
+        )
+      end
+
+      request_response_without_instana(method, *others, **options)
+    rescue => e
+      ::Instana.tracer.log_error(e)
+      raise
+    ensure
+      ::Instana.tracer.log_exit(:'net-http', kv_payload)
+    end
+
+    ::Instana.logger.warn 'Instrumenting GRPC client'
+
+    alias request_response_without_instana request_response
+    alias request_response request_response_with_instana
+  end
+end
+
+if defined?(GRPC::RpcDesc)
+  GRPC::RpcDesc.class_eval do
+    def run_server_method_with_instana(active_call, mth)
+      unless ::Instana.tracer.tracing?
+        run_server_method_without_instana(active_call, mth)
+      end
+
+      metadata = active_call.metadata
+
+      kvs = { http: {} }
+      kvs[:http][:method] = 'GRPC'
+      kvs[:http][:url] = "/#{mth.owner.service_name}/#{name}"
+      kvs[:http][:host] = Socket.gethostname
+
+      incoming_context = {}
+      if metadata.key?('x-instana-t')
+        incoming_context[:trace_id]  = ::Instana::Util.header_to_id(metadata['x-instana-t'])
+        incoming_context[:span_id]   = ::Instana::Util.header_to_id(metadata['x-instana-s']) if metadata.key?('x-instana-s')
+        incoming_context[:level]     = metadata['x-instana-l'] if metadata.key?('x-instana-l')
+      end
+
+      ::Instana.tracer.log_start_or_continue(:rack, {}, incoming_context)
+      run_server_method_without_instana(active_call, mth)
+    rescue => e
+      ::Instana.tracer.log_error(e)
+      raise
+    ensure
+      ::Instana.tracer.log_end(:rack, kvs)
+    end
+
+    ::Instana.logger.warn 'Instrumenting GRPC server'
+
+    alias run_server_method_without_instana run_server_method
+    alias run_server_method run_server_method_with_instana
+  end
+end

--- a/lib/instana/instrumentation/grpc.rb
+++ b/lib/instana/instrumentation/grpc.rb
@@ -1,87 +1,105 @@
+call_types = [:request_response, :client_streamer, :server_streamer, :bidi_streamer]
+
 if defined?(GRPC::ActiveCall)
-  GRPC::ClientStub.class_eval do
-    def request_response_with_instana(method, *others, **options)
-      unless ::Instana.tracer.tracing?
-        return request_response_without_instana(method, *others, **options)
-      end
+  call_types.each do |call_type|
+    GRPC::ClientStub.class_eval <<-RUBY, __FILE__, __LINE__ + 1
+      def #{call_type}_with_instana(method, *others, **options)
+        unless ::Instana.tracer.tracing?
+          return #{call_type}_without_instana(method, *others, **options)
+        end
 
-      kvs = {
-        rpc: {
-          flavor: :grpc,
-          host: @host,
-          call: method
+        kvs = {
+          rpc: {
+            flavor: :grpc,
+            host: @host,
+            call: method,
+            call_type: :#{call_type}
+          }
         }
-      }
-      ::Instana.tracer.log_entry(:'rpc-client', {})
+        ::Instana.tracer.log_entry(:'rpc-client', kvs)
 
-      context = ::Instana.tracer.context
-      if context
-        options[:metadata] = (options[:metadata] || {}).merge(
-          'x-instana-t' => context.trace_id_header,
-          'x-instana-s' => context.span_id_header
-        )
+        context = ::Instana.tracer.context
+        if context
+          options[:metadata] = (options[:metadata] || {}).merge(
+            'x-instana-t' => context.trace_id_header,
+            'x-instana-s' => context.span_id_header
+          )
+        end
+
+        #{call_type}_without_instana(method, *others, **options)
+      rescue => e
+        kvs[:rpc][:error] = true
+        ::Instana.tracer.log_info(kvs)
+        ::Instana.tracer.log_error(e)
+        raise
+      ensure
+        ::Instana.tracer.log_exit(:'rpc-client', {})
       end
 
-      request_response_without_instana(method, *others, **options)
-    rescue => e
-      kvs[:rpc][:error] = true
-      ::Instana.tracer.log_info(kvs)
-      ::Instana.tracer.log_error(e)
-      raise
-    ensure
-      ::Instana.tracer.log_exit(:'rpc-client', kvs)
-    end
+      ::Instana.logger.warn 'Instrumenting GRPC client'
 
-    ::Instana.logger.warn 'Instrumenting GRPC client'
-
-    alias request_response_without_instana request_response
-    alias request_response request_response_with_instana
+      alias #{call_type}_without_instana #{call_type}
+      alias #{call_type} #{call_type}_with_instana
+    RUBY
   end
 end
 
 if defined?(GRPC::RpcDesc)
-  [:handle_request_response, :handle_client_streamer].each do |method|
-    GRPC::RpcDesc.class_eval(
-      <<-RUBY, __FILE__, __LINE__ + 1
-        def #{method}_with_instana(active_call, mth)
-          metadata = active_call.metadata
+  call_types.each do |call_type|
+    GRPC::RpcDesc.class_eval <<-RUBY, __FILE__, __LINE__ + 1
+      def handle_#{call_type}_with_instana(active_call, mth)
+        metadata = active_call.metadata
 
-          incoming_context = {}
-          if metadata.key?('x-instana-t')
-            incoming_context[:trace_id]  = ::Instana::Util.header_to_id(metadata['x-instana-t'])
-            incoming_context[:span_id]   = ::Instana::Util.header_to_id(metadata['x-instana-s']) if metadata.key?('x-instana-s')
-            incoming_context[:level]     = metadata['x-instana-l'] if metadata.key?('x-instana-l')
-          end
-
-          kvs = {
-            rpc: {
-              flavor: :grpc,
-              host: Socket.gethostname,
-              call: "/\#{mth.owner.service_name}/\#{name}",
-              peer: {
-                address: active_call.peer
-              }
-            }
-          }
-          ::Instana.tracer.log_start_or_continue(
-            :'rpc-server', {}, incoming_context
-          )
-
-          #{method}_without_instana(active_call, mth)
-        rescue => e
-          kvs[:rpc][:error] = true
-          ::Instana.tracer.log_info(kvs)
-          ::Instana.tracer.log_error(e)
-          raise
-        ensure
-          ::Instana.tracer.log_end(:'rpc-server', kvs)
+        incoming_context = {}
+        if metadata.key?('x-instana-t')
+          incoming_context[:trace_id]  = ::Instana::Util.header_to_id(metadata['x-instana-t'])
+          incoming_context[:span_id]   = ::Instana::Util.header_to_id(metadata['x-instana-s']) if metadata.key?('x-instana-s')
+          incoming_context[:level]     = metadata['x-instana-l'] if metadata.key?('x-instana-l')
         end
 
-        ::Instana.logger.warn 'Instrumenting GRPC server'
+        kvs = {
+          rpc: {
+            flavor: :grpc,
+            host: Socket.gethostname,
+            call: "/\#{mth.owner.service_name}/\#{name}",
+            call_type: :#{call_type},
+            peer: {
+              address: active_call.peer
+            }
+          }
+        }
+        ::Instana.tracer.log_start_or_continue(
+          :'rpc-server', kvs, incoming_context
+        )
 
-        alias #{method}_without_instana #{method}
-        alias #{method} #{method}_with_instana
-      RUBY
-    )
+        handle_#{call_type}_without_instana(active_call, mth)
+      rescue => e
+        kvs[:rpc][:error] = true
+        ::Instana.tracer.log_info(kvs)
+        ::Instana.tracer.log_error(e)
+        raise
+      ensure
+        ::Instana.tracer.log_end(:'rpc-server', {}) if ::Instana.tracer.tracing?
+      end
+
+      ::Instana.logger.warn 'Instrumenting GRPC server'
+
+      alias handle_#{call_type}_without_instana handle_#{call_type}
+      alias handle_#{call_type} handle_#{call_type}_with_instana
+    RUBY
+  end
+
+  GRPC::BidiCall.class_eval do
+    def run_on_server_with_instana(*args)
+      run_on_server_without_instana(*args)
+    rescue => e
+      ::Instana.tracer.log_error(e)
+      raise
+    ensure
+      ::Instana.tracer.log_end(:'rpc-server', {}) if ::Instana.tracer.tracing?
+    end
+
+    alias run_on_server_without_instana run_on_server
+    alias run_on_server run_on_server_with_instana
   end
 end

--- a/lib/instana/instrumentation/grpc.rb
+++ b/lib/instana/instrumentation/grpc.rb
@@ -37,10 +37,6 @@ end
 if defined?(GRPC::RpcDesc)
   GRPC::RpcDesc.class_eval do
     def run_server_method_with_instana(active_call, mth)
-      unless ::Instana.tracer.tracing?
-        return run_server_method_without_instana(active_call, mth)
-      end
-
       metadata = active_call.metadata
 
       kvs = { http: {} }

--- a/lib/instana/instrumentation/grpc.rb
+++ b/lib/instana/instrumentation/grpc.rb
@@ -38,7 +38,7 @@ if defined?(GRPC::RpcDesc)
   GRPC::RpcDesc.class_eval do
     def run_server_method_with_instana(active_call, mth)
       unless ::Instana.tracer.tracing?
-        run_server_method_without_instana(active_call, mth)
+        return run_server_method_without_instana(active_call, mth)
       end
 
       metadata = active_call.metadata

--- a/lib/instana/instrumentation/grpc.rb
+++ b/lib/instana/instrumentation/grpc.rb
@@ -36,12 +36,12 @@ if defined?(GRPC::ActiveCall) && ::Instana.config[:'grpc'][:enabled]
         ::Instana.tracer.log_exit(:'rpc-client', {})
       end
 
-      ::Instana.logger.warn 'Instrumenting GRPC client'
 
       alias #{call_type}_without_instana #{call_type}
       alias #{call_type} #{call_type}_with_instana
     RUBY
   end
+  ::Instana.logger.warn 'Instrumenting GRPC client'
 end
 
 if defined?(GRPC::RpcDesc) && ::Instana.config[:'grpc'][:enabled]
@@ -82,10 +82,9 @@ if defined?(GRPC::RpcDesc) && ::Instana.config[:'grpc'][:enabled]
         ::Instana.tracer.log_end(:'rpc-server', {}) if ::Instana.tracer.tracing?
       end
 
-      ::Instana.logger.warn 'Instrumenting GRPC server'
-
       alias handle_#{call_type}_without_instana handle_#{call_type}
       alias handle_#{call_type} handle_#{call_type}_with_instana
     RUBY
   end
+  ::Instana.logger.warn 'Instrumenting GRPC server'
 end

--- a/lib/instana/instrumentation/grpc.rb
+++ b/lib/instana/instrumentation/grpc.rb
@@ -5,11 +5,13 @@ if defined?(GRPC::ActiveCall)
         return request_response_without_instana(method, *others, **options)
       end
 
-      ::Instana.tracer.log_entry(:'net-http')
-      kv_payload = { http: {} }
-      kv_payload[:http][:method] = 'GRPC'
-      kv_payload[:http][:host] = @host
-      kv_payload[:http][:url] = method
+      parts = method.split('/')
+      kvs = {
+        host: @host,
+        service: parts[1],
+        rpc: parts[2]
+      }
+      ::Instana.tracer.log_entry(:'grpc-call', kvs)
 
       context = ::Instana.tracer.context
       if context
@@ -24,7 +26,7 @@ if defined?(GRPC::ActiveCall)
       ::Instana.tracer.log_error(e)
       raise
     ensure
-      ::Instana.tracer.log_exit(:'net-http', kv_payload)
+      ::Instana.tracer.log_exit(:'grpc-call', {})
     end
 
     ::Instana.logger.warn 'Instrumenting GRPC client'
@@ -35,34 +37,41 @@ if defined?(GRPC::ActiveCall)
 end
 
 if defined?(GRPC::RpcDesc)
-  GRPC::RpcDesc.class_eval do
-    def run_server_method_with_instana(active_call, mth)
-      metadata = active_call.metadata
+  [:handle_request_response, :handle_client_streamer].each do |method|
+    GRPC::RpcDesc.class_eval(
+      <<-RUBY, __FILE__, __LINE__ + 1
+        def #{method}_with_instana(active_call, mth)
+          metadata = active_call.metadata
 
-      kvs = { http: {} }
-      kvs[:http][:method] = 'GRPC'
-      kvs[:http][:url] = "/#{mth.owner.service_name}/#{name}"
-      kvs[:http][:host] = Socket.gethostname
+          incoming_context = {}
+          if metadata.key?('x-instana-t')
+            incoming_context[:trace_id]  = ::Instana::Util.header_to_id(metadata['x-instana-t'])
+            incoming_context[:span_id]   = ::Instana::Util.header_to_id(metadata['x-instana-s']) if metadata.key?('x-instana-s')
+            incoming_context[:level]     = metadata['x-instana-l'] if metadata.key?('x-instana-l')
+          end
 
-      incoming_context = {}
-      if metadata.key?('x-instana-t')
-        incoming_context[:trace_id]  = ::Instana::Util.header_to_id(metadata['x-instana-t'])
-        incoming_context[:span_id]   = ::Instana::Util.header_to_id(metadata['x-instana-s']) if metadata.key?('x-instana-s')
-        incoming_context[:level]     = metadata['x-instana-l'] if metadata.key?('x-instana-l')
-      end
+          kvs = {
+            host: Socket.gethostname,
+            service: mth.owner.service_name,
+            rpc: name
+          }
+          ::Instana.tracer.log_start_or_continue(
+            :'grpc-server', kvs, incoming_context
+          )
 
-      ::Instana.tracer.log_start_or_continue(:rack, {}, incoming_context)
-      run_server_method_without_instana(active_call, mth)
-    rescue => e
-      ::Instana.tracer.log_error(e)
-      raise
-    ensure
-      ::Instana.tracer.log_end(:rack, kvs)
-    end
+          #{method}_without_instana(active_call, mth)
+        rescue => e
+          ::Instana.tracer.log_error(e)
+          raise
+        ensure
+          ::Instana.tracer.log_end(:'grpc-server', {})
+        end
 
-    ::Instana.logger.warn 'Instrumenting GRPC server'
+        ::Instana.logger.warn 'Instrumenting GRPC server'
 
-    alias run_server_method_without_instana run_server_method
-    alias run_server_method run_server_method_with_instana
+        alias #{method}_without_instana #{method}
+        alias #{method} #{method}_with_instana
+      RUBY
+    )
   end
 end

--- a/test/apps/grpc_server.rb
+++ b/test/apps/grpc_server.rb
@@ -28,6 +28,11 @@ module PingPongService
     rpc :PingWithClientStream, stream(PingRequest), PongReply
     rpc :PingWithServerStream, PingRequest, stream(PongReply)
     rpc :PingWithBidiStream, stream(PingRequest), stream(PongReply)
+
+    rpc :FailToPing, PingRequest, PongReply
+    rpc :FailToPingWithClientStream, stream(PingRequest), PongReply
+    rpc :FailToPingWithServerStream, PingRequest, stream(PongReply)
+    rpc :FailToPingWithBidiStream, stream(PingRequest), stream(PongReply)
   end
 
   Stub = Service.rpc_stub_class
@@ -46,15 +51,31 @@ class PingPongServer < PingPongService::Service
     PingPongService::PongReply.new(message: message)
   end
 
-  def ping_with_server_stream(request, active_call)
-    (0..5).map do |result|
-      PingPongService::PongReply.new(message: result.to_s)
+  def ping_with_server_stream(ping_request, active_call)
+    (0..5).map do |index|
+      PingPongService::PongReply.new(message: index.to_s)
     end
   end
 
-  def ping_with_bidi_stream(requests)
-    requests.map do |request|
-      PingPongService::PongReply.new(message: request.message)
+  def ping_with_bidi_stream(ping_requests)
+    ping_requests.map do |ping_request|
+      PingPongService::PongReply.new(message: ping_request.message)
     end
+  end
+
+  def fail_to_ping(ping_request, active_call)
+    raise 'Unexpected failed'
+  end
+
+  def fail_to_ping_with_client_stream(active_call)
+    raise 'Unexpected failed'
+  end
+
+  def fail_to_ping_with_server_stream(ping_request, active_call)
+    raise 'Unexpected failed'
+  end
+
+  def fail_to_ping_with_bidi_stream(ping_requests)
+    raise 'Unexpected failed'
   end
 end

--- a/test/apps/grpc_server.rb
+++ b/test/apps/grpc_server.rb
@@ -1,0 +1,60 @@
+require 'google/protobuf'
+
+Google::Protobuf::DescriptorPool.generated_pool.build do
+  add_message "PingPongService.PingRequest" do
+    optional :message, :string, 1
+  end
+  add_message "PingPongService.PongReply" do
+    optional :message, :string, 1
+  end
+end
+
+module PingPongService
+  PingRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("PingPongService.PingRequest").msgclass
+  PongReply = Google::Protobuf::DescriptorPool.generated_pool.lookup("PingPongService.PongReply").msgclass
+end
+require 'grpc'
+
+module PingPongService
+  # The greeting service definition.
+  class Service
+    include GRPC::GenericService
+
+    self.marshal_class_method = :encode
+    self.unmarshal_class_method = :decode
+    self.service_name = 'PingPongService'
+
+    rpc :Ping, PingRequest, PongReply
+    rpc :PingWithClientStream, stream(PingRequest), PongReply
+    rpc :PingWithServerStream, PingRequest, stream(PongReply)
+    rpc :PingWithBidiStream, stream(PingRequest), stream(PongReply)
+  end
+
+  Stub = Service.rpc_stub_class
+end
+
+class PingPongServer < PingPongService::Service
+  def ping(ping_request, active_call)
+    PingPongService::PongReply.new(message: "Hello #{ping_request.message}")
+  end
+
+  def ping_with_client_stream(active_call)
+    message = ''
+    active_call.each_remote_read do |req|
+      message += req.message
+    end
+    PingPongService::PongReply.new(message: message)
+  end
+
+  def ping_with_server_stream(request, active_call)
+    (0..5).map do |result|
+      PingPongService::PongReply.new(message: result.to_s)
+    end
+  end
+
+  def ping_with_bidi_stream(requests)
+    requests.map do |request|
+      PingPongService::PongReply.new(message: request.message)
+    end
+  end
+end

--- a/test/instrumentation/grpc_test.rb
+++ b/test/instrumentation/grpc_test.rb
@@ -23,7 +23,7 @@ class GrpcTest < Minitest::Test
     end
   end
 
-  def assert_client_trace(client_trace, call:, call_type:, error: nil)
+  def assert_client_trace(client_trace, call: '', call_type: '', error: nil)
     assert_equal 2, client_trace.spans.count
     spans = client_trace.spans.to_a
     first_span = spans[0]
@@ -51,7 +51,7 @@ class GrpcTest < Minitest::Test
     end
   end
 
-  def assert_server_trace(server_trace, call:, call_type:, error: nil)
+  def assert_server_trace(server_trace, call: '', call_type: '', error: nil)
     assert_equal 1, server_trace.spans.count
     span = server_trace.spans.to_a.first
 

--- a/test/instrumentation/grpc_test.rb
+++ b/test/instrumentation/grpc_test.rb
@@ -1,0 +1,134 @@
+require 'test_helper'
+
+class GrpcTest < Minitest::Test
+  def client_stub
+    PingPongService::Stub.new('127.0.0.1:50051', :this_channel_is_insecure)
+  end
+
+  def assert_client_trace(client_trace, call:, call_type:)
+    assert_equal 2, client_trace.spans.count
+    spans = client_trace.spans.to_a
+    first_span = spans[0]
+    second_span = spans[1]
+
+    # Span name validation
+    assert_equal :sdk, first_span[:n]
+    assert_equal :sdk, second_span[:n]
+
+    # first_span is the parent of second_span
+    assert_equal first_span.id, second_span[:p]
+
+    # data keys/values
+    refute_nil second_span.key?(:data)
+
+    data = second_span[:data][:sdk][:custom]
+    assert_equal '127.0.0.1:50051', data[:rpc][:host]
+    assert_equal :grpc, data[:rpc][:flavor]
+    assert_equal call, data[:rpc][:call]
+    assert_equal call_type, data[:rpc][:call_type]
+  end
+
+  def test_request_response
+    clear_all!
+    response = nil
+
+    Instana.tracer.start_or_continue_trace(:'rpc-client') do
+      response = client_stub.ping(
+        PingPongService::PingRequest.new(message: 'Hello World')
+      )
+    end
+
+    assert 'Hello World', response.message
+
+    assert_equal 2, ::Instana.processor.queue_count
+    traces = Instana.processor.queued_traces
+
+    server_trace = traces[0]
+    client_trace = traces[1]
+
+    assert_client_trace(
+      client_trace,
+      call: '/PingPongService/Ping',
+      call_type: :request_response
+    )
+  end
+
+  def test_client_streamer
+    clear_all!
+    response = nil
+
+    Instana.tracer.start_or_continue_trace(:'rpc-client') do
+      response = client_stub.ping_with_client_stream(
+        (0..5).map do |index|
+          PingPongService::PingRequest.new(message: index.to_s)
+        end
+      )
+    end
+
+    assert '01234', response.message
+
+    assert_equal 2, ::Instana.processor.queue_count
+    traces = Instana.processor.queued_traces
+
+    server_trace = traces[0]
+    client_trace = traces[1]
+
+    assert_client_trace(
+      client_trace,
+      call: '/PingPongService/PingWithClientStream',
+      call_type: :client_streamer
+    )
+  end
+
+  def test_server_streamer
+    clear_all!
+    responses = []
+
+    Instana.tracer.start_or_continue_trace(:'rpc-client') do
+      responses = client_stub.ping_with_server_stream(
+        PingPongService::PingRequest.new(message: 'Hello World')
+      )
+    end
+
+    assert %w(0 1 2 3 4), responses.map(&:message)
+
+    assert_equal 2, ::Instana.processor.queue_count
+    traces = Instana.processor.queued_traces
+
+    client_trace = traces[0]
+    server_trace = traces[1]
+
+    assert_client_trace(
+      client_trace,
+      call: '/PingPongService/PingWithServerStream',
+      call_type: :server_streamer
+    )
+  end
+
+  def test_bidi_streamer
+    clear_all!
+    responses = []
+
+    Instana.tracer.start_or_continue_trace(:'rpc-client') do
+      responses = client_stub.ping_with_bidi_stream(
+        (0..5).map do |index|
+          PingPongService::PingRequest.new(message: (index * 2).to_s)
+        end
+      )
+    end
+
+    assert %w(0 2 4 6 8), responses.to_a.map(&:message)
+
+    assert_equal 2, ::Instana.processor.queue_count
+    traces = Instana.processor.queued_traces
+
+    client_trace = traces[0]
+    server_trace = traces[1]
+
+    assert_client_trace(
+      client_trace,
+      call: '/PingPongService/PingWithBidiStream',
+      call_type: :bidi_streamer
+    )
+  end
+end

--- a/test/servers/grpc_50051.rb
+++ b/test/servers/grpc_50051.rb
@@ -2,11 +2,19 @@ require File.expand_path(File.dirname(__FILE__) + '/../apps/grpc_server.rb')
 
 ::Instana.logger.info "Booting instrumented gRPC server on port 50051 for tests."
 
-Thread.new do
+grpc_thread = Thread.new do
   s = GRPC::RpcServer.new
+  Thread.current[:server] = s
+
   s.add_http2_port('127.0.0.1:50051', :this_port_is_insecure)
   s.handle(PingPongServer)
   s.run_till_terminated
 end
 
-sleep(2)
+Minitest.after_run do
+  ::Instana.logger.info "Killing gRPC server"
+  grpc_thread[:server].stop
+  sleep 2
+end
+
+sleep 2

--- a/test/servers/grpc_50051.rb
+++ b/test/servers/grpc_50051.rb
@@ -1,0 +1,12 @@
+require File.expand_path(File.dirname(__FILE__) + '/../apps/grpc_server.rb')
+
+::Instana.logger.info "Booting instrumented gRPC server on port 50051 for tests."
+
+Thread.new do
+  s = GRPC::RpcServer.new
+  s.add_http2_port('127.0.0.1:50051', :this_port_is_insecure)
+  s.handle(PingPongServer)
+  s.run_till_terminated
+end
+
+sleep(2)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -20,6 +20,9 @@ require "./test/servers/rackapp_6511"
 case File.basename(ENV['BUNDLE_GEMFILE'])
 when /rails50|rails42|rails32/
   require './test/servers/rails_3205'
+when /libraries/
+  # Boot background grpc server
+  require './test/servers/grpc_50051'
 end
 
 WebMock.disable_net_connect!(allow_localhost: true)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -21,8 +21,7 @@ case File.basename(ENV['BUNDLE_GEMFILE'])
 when /rails50|rails42|rails32/
   require './test/servers/rails_3205'
 when /libraries/
-  # Boot background grpc server
-  require './test/servers/grpc_50051'
+  require './test/servers/grpc_50051.rb'
 end
 
 WebMock.disable_net_connect!(allow_localhost: true)


### PR DESCRIPTION
Hello there, my name is Minh Nguyen, from Employment Hero. I have a talk with Peter in Instana support center about the gRPC support. This pull is the implementation of gRPC support for the Ruby Sensor. As gRPC is official supported by Google and a official library is provided (https://github.com/grpc/grpc/tree/master/src/ruby), I follow the implementation of this library. I already test in my Company's environment and everything works like charm, except some problems with front-end display because `rpc-client` and `rpc-server` span kinds are not supported yet. So in this implementation, I treat `rpc-client` and `rpc-server` as a custom span kind. Perhaps after you guys add the support for them, I'll add to the registered span list.

Please give me some feedbacks about this implementation. Hope that the code quality is not so bad 😸 

cc @tienle, @longseespace 