### PR TITLE
Lower logging verbosity & levels

### DIFF
--- a/lib/instana/agent.rb
+++ b/lib/instana/agent.rb
@@ -204,7 +204,7 @@ module Instana
         false
       end
     rescue => e
-      Instana.logger.error "#{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}"
+      Instana.logger.info "#{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}"
       Instana.logger.debug e.backtrace.join("\r\n")
       return false
     ensure
@@ -245,7 +245,7 @@ module Instana
       end
       false
     rescue => e
-      Instana.logger.error "#{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}"
+      Instana.logger.debug "#{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}"
       Instana.logger.debug e.backtrace.join("\r\n")
     end
 
@@ -328,7 +328,7 @@ module Instana
       end
       false
     rescue => e
-      Instana.logger.error "#{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}"
+      Instana.logger.debug "#{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}"
       Instana.logger.debug e.backtrace.join("\r\n") unless ::Instana.test?
       return false
     end
@@ -426,7 +426,7 @@ module Instana
         @state = :unannounced
 
       else
-        ::Instana.logger.warn "Uknown agent state: #{state}"
+        ::Instana.logger.debug "Uknown agent state: #{state}"
       end
       ::Instana.collector.reset_timer!
       true
@@ -452,7 +452,7 @@ module Instana
     rescue Errno::ECONNREFUSED
       return nil
     rescue => e
-      Instana.logger.error "#{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}"
+      Instana.logger.debug "#{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}"
       Instana.logger.debug e.backtrace.join("\r\n") unless ::Instana.test?
       return nil
     end

--- a/lib/instana/collectors/gc.rb
+++ b/lib/instana/collectors/gc.rb
@@ -41,7 +41,7 @@ module Instana
         @this_gc[:heap_free] = stats[:heap_free_slot] || stats[:heap_free_slots] || stats[:heap_free_num]
         @this_gc
       rescue => e
-        ::Instana.logger.error "#{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}"
+        ::Instana.logger.info "#{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}"
         ::Instana.logger.debug e.backtrace.join("\r\n")
       end
     end

--- a/lib/instana/collectors/memory.rb
+++ b/lib/instana/collectors/memory.rb
@@ -21,7 +21,7 @@ module Instana
         @this_mem[:rss_size] = ::GetProcessMem.new(Process.pid).kb
         @this_mem
       rescue => e
-        ::Instana.logger.error "#{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}"
+        ::Instana.logger.info "#{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}"
         ::Instana.logger.debug e.backtrace.join("\r\n")
       end
     end

--- a/lib/instana/collectors/thread.rb
+++ b/lib/instana/collectors/thread.rb
@@ -17,7 +17,7 @@ module Instana
         @this_count[:count] = ::Thread.list.count
         @this_count
       rescue => e
-        ::Instana.logger.error "#{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}"
+        ::Instana.logger.info "#{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}"
         ::Instana.logger.debug e.backtrace.join("\r\n")
       end
     end

--- a/lib/instana/helpers.rb
+++ b/lib/instana/helpers.rb
@@ -15,7 +15,7 @@ module Instana
 
         ERB.new(EUM_SNIPPET).result
       rescue => e
-        Instana.logger.error "#{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}"
+        Instana.logger.info "#{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}"
         Instana.logger.debug e.backtrace.join("\r\n")
         return nil
       end
@@ -31,7 +31,7 @@ module Instana
 
         ERB.new(EUM_TEST_SNIPPET).result
       rescue => e
-        Instana.logger.error "#{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}"
+        Instana.logger.info "#{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}"
         Instana.logger.debug e.backtrace.join("\r\n")
         return nil
       end

--- a/lib/instana/util.rb
+++ b/lib/instana/util.rb
@@ -119,7 +119,7 @@ module Instana
 
         data
       rescue => e
-        ::Instana.logger.error "#{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}"
+        ::Instana.logger.debug "#{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}"
         ::Instana.logger.debug e.backtrace.join("\r\n")
         return data
       end
@@ -193,7 +193,7 @@ module Instana
         end
         [id.to_i].pack('q>').unpack('H*')[0].gsub(/^0+/, '')
       rescue => e
-        Instana.logger.error "#{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}"
+        Instana.logger.info "#{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}"
         Instana.logger.debug e.backtrace.join("\r\n")
       end
 
@@ -216,7 +216,7 @@ module Instana
         end
         [header_id].pack("H*").unpack("q>")[0]
       rescue => e
-        Instana.logger.error "#{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}"
+        Instana.logger.info "#{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}"
         Instana.logger.debug e.backtrace.join("\r\n")
       end
     end


### PR DESCRIPTION
This PR improves logging by lowering the logger levels of non-critical exceptions from `error` down
to `info` or `debug`.