### PR TITLE
Grpc Instrumentation is reported using SDK span type

### DIFF
--- a/gemfiles/libraries.gemfile
+++ b/gemfiles/libraries.gemfile
@@ -13,10 +13,10 @@ end
 group :development do
   gem 'ruby-debug',   :platforms => [:mri_18, :jruby]
   gem 'debugger',     :platform  =>  :mri_19
-  gem 'byebug',       :platforms => [:mri_20, :mri_21, :mri_22, :mri_23]
+  gem 'byebug',       :platforms => [:mri_20, :mri_21, :mri_22, :mri_23, :mri_24]
   if RUBY_VERSION > '1.8.7'
     gem 'pry'
-    gem 'pry-byebug', :platforms => [:mri_20, :mri_21, :mri_22, :mri_23]
+    gem 'pry-byebug', :platforms => [:mri_20, :mri_21, :mri_22, :mri_23, :mri_24]
   else
     gem 'pry', '0.9.12.4'
   end

--- a/lib/instana/tracing/span.rb
+++ b/lib/instana/tracing/span.rb
@@ -1,9 +1,11 @@
 module Instana
   class Span
-    REGISTERED_SPANS = [ :actioncontroller, :actionview, :activerecord, :excon, :memcache, :'net-http', :rack, :render ].freeze
-    ENTRY_SPANS = [ :rack ].freeze
-    EXIT_SPANS = [ :'net-http', :excon, :activerecord ].freeze
-    HTTP_SPANS = ENTRY_SPANS + EXIT_SPANS
+    REGISTERED_SPANS = [ :actioncontroller, :actionview, :activerecord, :excon,
+                         :memcache, :'net-http', :rack, :render, :'rpc-client',
+                         :'rpc-server' ].freeze
+    ENTRY_SPANS = [ :rack, :'rpc-server' ].freeze
+    EXIT_SPANS = [ :activerecord, :excon, :'net-http', :'rpc-client' ].freeze
+    HTTP_SPANS = [ :rack, :excon, :'net-http' ].freeze
 
     attr_accessor :parent
     attr_accessor :baggage


### PR DESCRIPTION
This should be reported as a registered span as `rpc-client` and `rpc-server` are registered span types.

Also some UI issues to be resolved:

- [x] `call_type` isn't displayed
- [x] Span block shows Unknown

![screen shot 2017-07-04 at 15 37 04](https://user-images.githubusercontent.com/395132/27832326-ab2d4290-60ce-11e7-964f-3f18398e1a58.png)

cc: @nguyenquangminh0711 FYI some polishing work for me to do on our backend & UI.