### PR TITLE
Lower runtime version requirement for ffi

### DIFF
--- a/instana.gemspec
+++ b/instana.gemspec
@@ -36,5 +36,5 @@ Gem::Specification.new do |spec|
 
   # Indirect dependency
   # https://github.com/instana/ruby-sensor/issues/10
-  spec.add_runtime_dependency('ffi', '>= 1.9.3')
+  spec.add_runtime_dependency('ffi', '>= 1.8.1')
 end

--- a/lib/instana/tracing/processor.rb
+++ b/lib/instana/tracing/processor.rb
@@ -25,7 +25,7 @@ module Instana
     #
     # @param [Trace] the trace to be added to the queue
     def add(trace)
-      ::Instana.logger.debug("Queuing completed trace id: #{trace.id}")
+      # ::Instana.logger.debug("Queuing completed trace id: #{trace.id}")
       @queue.push(trace)
     end
 

--- a/test/instrumentation/grpc_test.rb
+++ b/test/instrumentation/grpc_test.rb
@@ -79,6 +79,9 @@ class GrpcTest < Minitest::Test
 
     assert 'Hello World', response.message
 
+    # Pause for a split second to allow traces to be queued
+    sleep 0.2
+
     assert_equal 2, ::Instana.processor.queue_count
     client_trace, server_trace = differentiate_trace(
       Instana.processor.queued_traces
@@ -111,6 +114,9 @@ class GrpcTest < Minitest::Test
 
     assert '01234', response.message
 
+    # Pause for a split second to allow traces to be queued
+    sleep 0.2
+
     assert_equal 2, ::Instana.processor.queue_count
     client_trace, server_trace = differentiate_trace(
       Instana.processor.queued_traces
@@ -138,9 +144,10 @@ class GrpcTest < Minitest::Test
         PingPongService::PingRequest.new(message: 'Hello World')
       )
     end
-    sleep 1
-
     assert %w(0 1 2 3 4), responses.map(&:message)
+
+    # Pause for a split second to allow traces to be queued
+    sleep 0.2
 
     assert_equal 2, ::Instana.processor.queue_count
     client_trace, server_trace = differentiate_trace(
@@ -175,6 +182,9 @@ class GrpcTest < Minitest::Test
 
     assert %w(0 2 4 6 8), responses.to_a.map(&:message)
 
+    # Pause for a split second to allow traces to be queued
+    sleep 0.2
+
     assert_equal 2, ::Instana.processor.queue_count
     client_trace, server_trace = differentiate_trace(
       Instana.processor.queued_traces
@@ -201,6 +211,9 @@ class GrpcTest < Minitest::Test
       rescue
       end
     end
+
+    # Pause for a split second to allow traces to be queued
+    sleep 0.2
 
     assert_equal 2, ::Instana.processor.queue_count
     client_trace, server_trace = differentiate_trace(
@@ -234,6 +247,9 @@ class GrpcTest < Minitest::Test
       end
     end
 
+    # Pause for a split second to allow traces to be queued
+    sleep 0.2
+
     assert_equal 2, ::Instana.processor.queue_count
     client_trace, server_trace = differentiate_trace(
       Instana.processor.queued_traces
@@ -264,7 +280,9 @@ class GrpcTest < Minitest::Test
       rescue
       end
     end
-    sleep 1
+
+    # Pause for a split second to allow traces to be queued
+    sleep 0.2
 
     assert_equal 2, ::Instana.processor.queue_count
     client_trace, server_trace = differentiate_trace(
@@ -294,7 +312,9 @@ class GrpcTest < Minitest::Test
         end
       )
     end
-    sleep 1
+
+    # Pause for a split second to allow traces to be queued
+    sleep 0.2
 
     assert_equal 2, ::Instana.processor.queue_count
     client_trace, server_trace = differentiate_trace(


### PR DESCRIPTION
This lowers the version requirement of ffi to 1.8.1 (from April 2013).

By default, a first time `bundle install` or a `bundle update` will always get the latest version available but this helps those who may have previously version locked ffi to an earlier version (either directly or indirectly via another gem).