### PR TITLE
Track and occasionally check background thread

### DIFF
--- a/lib/instana.rb
+++ b/lib/instana.rb
@@ -5,9 +5,8 @@ require "instana/setup"
 #
 #   gem "instana", :require => "instana/setup"
 #
-# ...and manually call ::Instana.agent.start in the thread
-# of your choice
+# ...and override ::Instana::Agent.spawn_background_thread to boot
+# the thread of your choice.
 #
-Thread.new do
-  ::Instana.agent.start
-end
+
+::Instana.agent.spawn_background_thread

--- a/lib/instana/tracing/processor.rb
+++ b/lib/instana/tracing/processor.rb
@@ -25,6 +25,11 @@ module Instana
     #
     # @param [Trace] the trace to be added to the queue
     def add(trace)
+      # Do a quick checkup on our background thread.
+      if ::Instana.agent.collect_thread.nil? || !::Instana.agent.collect_thread.alive?
+        ::Instana.agent.spawn_background_thread
+      end
+
       # ::Instana.logger.debug("Queuing completed trace id: #{trace.id}")
       @queue.push(trace)
     end


### PR DESCRIPTION
We've found a case where the background thread may be non-existent (e.g it dies or is killed).
In such a case, Ruby metrics are no longer reported, and the trace queue fills up indefinitely.

This PR tracks the spawned thread and makes occasional checks on it's health.
It will respawn the background thread if needed.