### PR TITLE
Performance: Use clock_gettime instead of converting Time object

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ cache:
     - vendor/bundle
 
 rvm:
+  - 2.4.1
   - 2.3.3
   - 2.2.6
   - 2.1.9
-  - ruby-2.0.0-p648
 
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,11 +38,8 @@ matrix:
     # Rails 5.0+ requires Ruby 2.2.2 or higher
     - rvm: 2.1.9
       gemfile: gemfiles/rails50.gemfile
-    - rvm: ruby-2.0.0-p648
-      gemfile: gemfiles/rails50.gemfile
-    - rvm: ruby-2.0.0-p648
-      gemfile: gemfiles/rails42.gemfile
-    - rvm: ruby-2.0.0-p648
+    # Rails 3.2 doesn't work on Ruby 2.4.1
+    - rvm: 2.4.1
       gemfile: gemfiles/rails32.gemfile
 
 notifications:

--- a/Rakefile
+++ b/Rakefile
@@ -31,7 +31,8 @@ Rake::TestTask.new(:test) do |t|
   else
     t.test_files = FileList['test/agent/*_test.rb'] +
                    FileList['test/tracing/*_test.rb'] +
-                   FileList['test/profiling/*_test.rb']
+                   FileList['test/profiling/*_test.rb'] +
+                   FileList['test/benchmarks/bench_*.rb']
   end
 end
 

--- a/benchmarks/opentracing.rb
+++ b/benchmarks/opentracing.rb
@@ -1,0 +1,26 @@
+#!/usr/bin/env ruby
+require "bundler"
+Bundler.require(:default)
+
+require "benchmark"
+
+Benchmark.bm do |x|
+  x.report("start_span, finish:             ") {
+    50_000.times {
+      ::Instana.tracer.start_span(:blah).finish
+    }
+  }
+
+  x.report("start_span, set_tag(5x), finish:") {
+    50_000.times {
+      span = ::Instana.tracer.start_span(:blah)
+      span.set_tag(:blah, 1)
+      span.set_tag(:dog, 1)
+      span.set_tag(:moon, "ok")
+      span.set_tag(:ape, 1)
+      span.set_tag(:blah, 1)
+      span.finish
+    }
+  }
+
+end

--- a/benchmarks/time_processing.rb
+++ b/benchmarks/time_processing.rb
@@ -1,0 +1,12 @@
+#!/usr/bin/env ruby
+require "bundler"
+Bundler.require(:default)
+
+require "benchmark"
+
+# Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond)
+
+Benchmark.bm do |x|
+  x.report("Time.now:     ") { 1_000_000.times { (Time.now.to_f * 1000).floor } }
+  x.report("get_clocktime:") { 1_000_000.times { Process.clock_gettime(Process::CLOCK_REALTIME, :millisecond) } }
+end

--- a/gemfiles/rails32.gemfile
+++ b/gemfiles/rails32.gemfile
@@ -33,7 +33,6 @@ end
 gem 'rails', '3.2.22.5'
 gem 'pg'
 gem 'mysql2', '~> 0.3.10'
-gem 'mysql'
 
 # Gems used only for assets and not required
 # in production environments by default.

--- a/gemfiles/rails42.gemfile
+++ b/gemfiles/rails42.gemfile
@@ -30,7 +30,7 @@ group :development do
   end
 end
 
-gem 'rails', '4.2.7.1'
+gem 'rails', '4.2.9'
 gem 'sqlite3'
 gem 'sass-rails', '~> 5.0'
 gem 'uglifier', '>= 1.3.0'
@@ -43,7 +43,6 @@ gem 'jbuilder', '~> 2.0'
 gem 'sdoc', '~> 0.4.0', group: :doc
 gem "pg"
 gem "mysql2"
-gem "mysql"
 
 # Include the Instana Ruby gem's base set of gems
 gemspec :path => File.expand_path(File.dirname(__FILE__) + '/../')

--- a/instana.gemspec
+++ b/instana.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.test_files    = Dir.glob("{test}/**/*.rb")
 
-  spec.required_ruby_version = '>= 2.0'
+  spec.required_ruby_version = '>= 2.1'
 
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/instana/agent.rb
+++ b/lib/instana/agent.rb
@@ -14,7 +14,6 @@ module Instana
     attr_accessor :process
     attr_accessor :collect_thread
     attr_accessor :thread_spawn_lock
-    attr_accessor :last_discover_run
 
     LOCALHOST = '127.0.0.1'.freeze
     MIME_JSON = 'application/json'.freeze
@@ -354,13 +353,7 @@ module Instana
     # @return [Hash] a hash with :agent_host, :agent_port values or empty hash
     #
     def run_discovery
-      unless ENV.key?('INSTANA_GEM_TEST')
-        # Only run discovery every 3 minutes
-        return unless @last_discover_run && ((Time.now - @last_discover_run) > 120)
-      end
-
       discovered = {}
-      @last_discover_run = Time.now
 
       ::Instana.logger.debug "#{__method__}: Running agent discovery..."
 

--- a/lib/instana/agent.rb
+++ b/lib/instana/agent.rb
@@ -354,8 +354,10 @@ module Instana
     # @return [Hash] a hash with :agent_host, :agent_port values or empty hash
     #
     def run_discovery
-      # Only run discovery every 3 minutes
-      return unless @last_discover_run && ((Time.now - @last_discover_run) > 120)
+      unless ENV.key?('INSTANA_GEM_TEST')
+        # Only run discovery every 3 minutes
+        return unless @last_discover_run && ((Time.now - @last_discover_run) > 120)
+      end
 
       discovered = {}
       @last_discover_run = Time.now

--- a/lib/instana/agent.rb
+++ b/lib/instana/agent.rb
@@ -14,6 +14,7 @@ module Instana
     attr_accessor :process
     attr_accessor :collect_thread
     attr_accessor :thread_spawn_lock
+    attr_accessor :last_discover_run
 
     LOCALHOST = '127.0.0.1'.freeze
     MIME_JSON = 'application/json'.freeze
@@ -353,7 +354,11 @@ module Instana
     # @return [Hash] a hash with :agent_host, :agent_port values or empty hash
     #
     def run_discovery
+      # Only run discovery every 3 minutes
+      return unless @last_discover_run && ((Time.now - @last_discover_run) > 120)
+
       discovered = {}
+      @last_discover_run = Time.now
 
       ::Instana.logger.debug "#{__method__}: Running agent discovery..."
 

--- a/lib/instana/tracer.rb
+++ b/lib/instana/tracer.rb
@@ -135,7 +135,7 @@ module Instana
     # @param name [String] the name of the span to end
     # @param kvs [Hash] list of key values to be reported in the span
     #
-    def log_end(name, kvs = {}, end_time = Time.now)
+    def log_end(name, kvs = {}, end_time = ::Instana::Util.now_in_ms)
       return unless tracing?
 
       if ::Instana.debug? || ::Instana.test?
@@ -261,7 +261,7 @@ module Instana
     #
     # @return [Span]
     #
-    def start_span(operation_name, child_of: nil, start_time: Time.now, tags: nil)
+    def start_span(operation_name, child_of: nil, start_time: ::Instana::Util.now_in_ms, tags: nil)
       return unless ::Instana.agent.ready?
 
       if tracing?

--- a/lib/instana/tracer.rb
+++ b/lib/instana/tracer.rb
@@ -146,14 +146,16 @@ module Instana
 
       self.current_trace.finish(kvs, end_time)
 
-      if !self.current_trace.has_async? ||
-          (self.current_trace.has_async? && self.current_trace.complete?)
-        Instana.processor.add(self.current_trace)
-      else
-        # This trace still has outstanding/uncompleted asynchronous spans.
-        # Put it in the staging queue until the async span closes out or
-        # 5 minutes has passed.  Whichever comes first.
-        Instana.processor.stage(self.current_trace)
+      if ::Instana.agent.ready?
+        if !self.current_trace.has_async? ||
+            (self.current_trace.has_async? && self.current_trace.complete?)
+          Instana.processor.add(self.current_trace)
+        else
+          # This trace still has outstanding/uncompleted asynchronous spans.
+          # Put it in the staging queue until the async span closes out or
+          # 5 minutes has passed.  Whichever comes first.
+          Instana.processor.stage(self.current_trace)
+        end
       end
       self.current_trace = nil
     end
@@ -262,7 +264,7 @@ module Instana
     # @return [Span]
     #
     def start_span(operation_name, child_of: nil, start_time: ::Instana::Util.now_in_ms, tags: nil)
-      return unless ::Instana.agent.ready?
+      # return unless ::Instana.agent.ready?
 
       if tracing?
         span = self.current_trace.new_span(operation_name, tags, start_time, child_of)

--- a/lib/instana/tracing/trace.rb
+++ b/lib/instana/tracing/trace.rb
@@ -17,7 +17,7 @@ module Instana
     #     :span_id the ID of the parent span (must be an unsigned hex-string)
     #     :level specifies data collection level (optional)
     #
-    def initialize(name, kvs = nil, incoming_context = {}, start_time = Time.now)
+    def initialize(name, kvs = nil, incoming_context = {}, start_time = ::Instana::Util.now_in_ms)
       # The collection of spans that make
       # up this trace.
       @spans = Set.new
@@ -56,7 +56,7 @@ module Instana
     # @param name [String] the name of the span to start
     # @param kvs [Hash] list of key values to be reported in the span
     #
-    def new_span(name, kvs = nil, start_time = Time.now, child_of = nil)
+    def new_span(name, kvs = nil, start_time = ::Instana::Util.now_in_ms, child_of = nil)
       return unless @current_span
 
       if child_of && child_of.is_a?(::Instana::Span)
@@ -104,7 +104,7 @@ module Instana
     #
     # @param kvs [Hash] list of key values to be reported in the span
     #
-    def end_span(kvs = {}, end_time = Time.now)
+    def end_span(kvs = {}, end_time = ::Instana::Util.now_in_ms)
       @current_span.close(end_time)
       add_info(kvs) if kvs && !kvs.empty?
       @current_span = @current_span.parent unless @current_span.is_root?
@@ -116,7 +116,7 @@ module Instana
     #
     # @param kvs [Hash] list of key values to be reported in the span
     #
-    def finish(kvs = {}, end_time = Time.now)
+    def finish(kvs = {}, end_time = ::Instana::Util.now_in_ms)
       end_span(kvs, end_time)
     end
 

--- a/lib/instana/tracing/trace.rb
+++ b/lib/instana/tracing/trace.rb
@@ -109,16 +109,7 @@ module Instana
       add_info(kvs) if kvs && !kvs.empty?
       @current_span = @current_span.parent unless @current_span.is_root?
     end
-
-    # Closes out the final span in this trace and runs any finalizer
-    # steps required.
-    # This should be called only when on the root span to end the trace.
-    #
-    # @param kvs [Hash] list of key values to be reported in the span
-    #
-    def finish(kvs = {}, end_time = ::Instana::Util.now_in_ms)
-      end_span(kvs, end_time)
-    end
+    alias finish end_span
 
     ###########################################################################
     # Asynchronous Methods

--- a/lib/instana/util.rb
+++ b/lib/instana/util.rb
@@ -158,19 +158,21 @@ module Instana
         process
       end
 
-      # Get the current time in milliseconds
+      # Get the current time in milliseconds from the epoch
       #
       # @return [Integer] the current time in milliseconds
       #
-      def ts_now
-        (Time.now.to_f * 1000).floor
+      def now_in_ms
+        Process.clock_gettime(Process::CLOCK_REALTIME, :millisecond)
       end
+      # Prior method name support.  To be deprecated when appropriate.
+      alias ts_now now_in_ms
 
       # Convert a Time value to milliseconds
       #
       # @param time [Time]
       #
-      def time_to_ms(time = Time.now)
+      def time_to_ms(time)
         (time.to_f * 1000).floor
       end
 

--- a/test/benchmarks/bench_id_generation.rb
+++ b/test/benchmarks/bench_id_generation.rb
@@ -1,0 +1,11 @@
+require 'test_helper'
+
+class BenchIDs < Minitest::Benchmark
+  def bench_generate_id
+    assert_performance_constant do |input|
+      500_000.times do
+        ::Instana::Util.generate_id
+      end
+    end
+  end
+end

--- a/test/benchmarks/bench_opentracing.rb
+++ b/test/benchmarks/bench_opentracing.rb
@@ -1,0 +1,13 @@
+require 'test_helper'
+
+class BenchOpenTracing < Minitest::Benchmark
+  def bench_start_finish_span
+    assert_performance_constant do |input|
+      10_000.times do
+        span = ::Instana.tracer.start_span(:blah)
+        span.set_tag(:zero, 0)
+        span.finish
+      end
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,6 +9,7 @@ require "minitest/autorun"
 require "minitest/reporters"
 require "minitest/debugger" if ENV['DEBUG']
 require 'webmock/minitest'
+require "minitest/benchmark"
 
 require "instana/test"
 ::Instana::Test.setup_environment

--- a/test/tracing/custom_test.rb
+++ b/test/tracing/custom_test.rb
@@ -22,6 +22,11 @@ class CustomTracingTest < Minitest::Test
     first_span = t.spans.first
     assert_equal :sdk, first_span[:n]
 
+    assert first_span[:ts].is_a?(Integer)
+    assert first_span[:ts] > 0
+    assert first_span[:d].is_a?(Integer)
+    assert first_span[:d].between?(0, 5)
+
     assert first_span.key?(:data)
     assert first_span[:data].key?(:sdk)
     assert first_span[:data][:sdk].key?(:custom)
@@ -63,6 +68,11 @@ class CustomTracingTest < Minitest::Test
     assert t.valid?
 
     first_span, second_span = t.spans.to_a
+
+    assert first_span[:ts].is_a?(Integer)
+    assert first_span[:ts] > 0
+    assert first_span[:d].is_a?(Integer)
+    assert first_span[:d].between?(0, 5)
 
     assert_equal :rack, first_span[:n]
     assert first_span.key?(:data)
@@ -117,12 +127,22 @@ class CustomTracingTest < Minitest::Test
 
     first_span, second_span = t.spans.to_a
 
+    assert first_span[:ts].is_a?(Integer)
+    assert first_span[:ts] > 0
+    assert first_span[:d].is_a?(Integer)
+    assert first_span[:d].between?(0, 5)
+
     assert_equal :rack, first_span[:n]
     assert first_span.key?(:data)
     assert first_span[:data].key?(:on_trace_start)
     assert_equal 1, first_span[:data][:on_trace_start]
     assert first_span[:data].key?(:on_trace_end)
     assert_equal 1, first_span[:data][:on_trace_end]
+
+    assert second_span[:ts].is_a?(Integer)
+    assert second_span[:ts] > 0
+    assert second_span[:d].is_a?(Integer)
+    assert second_span[:d].between?(0, 5)
 
     assert_equal :sdk, second_span[:n]
     assert second_span.key?(:data)

--- a/test/tracing/tracer_test.rb
+++ b/test/tracing/tracer_test.rb
@@ -27,7 +27,7 @@ class TracerTest < Minitest::Test
 
     ::Instana.tracer.start_or_continue_trace(:rack, {:one => 1}) do
       assert_equal true, ::Instana.tracer.tracing?
-      sleep 0.3
+      sleep 0.1
     end
 
     traces = ::Instana.processor.queued_traces
@@ -39,6 +39,9 @@ class TracerTest < Minitest::Test
     first_span = t.spans.first
     assert_equal :rack, first_span[:n]
     assert_equal :ruby, first_span[:ta]
+    assert first_span[:ts].is_a?(Integer)
+    assert first_span[:d].is_a?(Integer)
+    assert first_span[:d].between?(100, 130)
     assert first_span.key?(:data)
     assert_equal 1, first_span[:data][:one]
     assert first_span.key?(:f)
@@ -47,7 +50,7 @@ class TracerTest < Minitest::Test
     assert_equal ::Instana.agent.agent_uuid, first_span[:f][:h]
   end
 
-  def test_errors_are_properly_propogated
+  def test_errors_are_properly_propagated
     clear_all!
     exception_raised = false
     begin
@@ -69,6 +72,10 @@ class TracerTest < Minitest::Test
     first_span = t.spans.first
     assert_equal :rack, first_span[:n]
     assert_equal :ruby, first_span[:ta]
+    assert first_span[:ts].is_a?(Integer)
+    assert first_span[:ts] > 0
+    assert first_span[:d].is_a?(Integer)
+    assert first_span[:d].between?(0, 5)
     assert first_span.key?(:data)
     assert_equal 1, first_span[:data][:one]
     assert first_span.key?(:f)


### PR DESCRIPTION
We currently use a Time object, convert it to a float, multiply it by 1000 (and floor it) just to get the current time in milliseconds since the epoch.

Instead, we can use `Process.clock_gettime` to get the current epoch time in milliseconds directly.

- [x] `Process.clock_gettime` support was added in Ruby 2.1 so we either need to add a work around for Ruby 2.0 or drop Ruby 2.0 support for now.