### PR TITLE
Loosen up the dependency on timers to >= 4.0

### DIFF
--- a/instana.gemspec
+++ b/instana.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency('sys-proctable', '>= 1.1.3')
   spec.add_runtime_dependency('get_process_mem', '>= 0.2.1')
-  spec.add_runtime_dependency('timers', '>= 4.1.0')
+  spec.add_runtime_dependency('timers', '>= 4.0.0')
 
   # Indirect dependency
   # https://github.com/instana/ruby-sensor/issues/10


### PR DESCRIPTION
Some users are locked into an earlier version of timers that we currently allow.  This PR lowers the minimum version required (v4+).