### PR TITLE
Switch to Oj for faster json processing.

### DIFF
--- a/instana.gemspec
+++ b/instana.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency('sys-proctable', '>= 1.1.3')
   spec.add_runtime_dependency('get_process_mem', '>= 0.2.1')
   spec.add_runtime_dependency('timers', '>= 4.0.0')
+  spec.add_runtime_dependency('oj', '~> 3.3')
 
   # Indirect dependency
   # https://github.com/instana/ruby-sensor/issues/10

--- a/test/agent/agent_test.rb
+++ b/test/agent/agent_test.rb
@@ -1,4 +1,7 @@
 require 'test_helper'
+require 'oj'
+
+Oj.default_options = {:mode => :strict}
 
 class AgentTest < Minitest::Test
   def test_agent_host_detection
@@ -65,7 +68,7 @@ class AgentTest < Minitest::Test
     ::Instana.agent.instance_variable_set(:@discovered, discovery)
 
     url = "http://#{::Instana.config[:agent_host]}:#{::Instana.config[:agent_port]}/com.instana.plugin.ruby.discovery"
-    json = { 'pid' => Process.pid, 'agentUuid' => 'abc' }.to_json
+    json = Oj.dump({ 'pid' => Process.pid, 'agentUuid' => 'abc' })
     stub_request(:put, url).to_return(:body => json, :status => 200)
 
     assert_equal true, ::Instana.agent.announce_sensor
@@ -92,7 +95,7 @@ class AgentTest < Minitest::Test
     ::Instana.agent.instance_variable_set(:@discovered, discovery)
 
     url = "http://#{::Instana.config[:agent_host]}:#{::Instana.config[:agent_port]}/com.instana.plugin.ruby.discovery"
-    json = { 'pid' => Process.pid, 'agentUuid' => 'abc' }.to_json
+    json = Oj.dump({ 'pid' => Process.pid, 'agentUuid' => 'abc' })
     stub_request(:put, url).to_return(:body => json, :status => 200)
     ::Instana.agent.announce_sensor
 


### PR DESCRIPTION
Switching to [Oj](https://github.com/ohler55/oj) gives us:

* faster json processing
* less memory
* less allocated objects

Some Ruby JSON related benchmarks are here:
https://github.com/stereobooster/ruby-json-benchmark