### PR TITLE
Fix gem interface backward compatibilities

### DIFF
--- a/lib/instana/instrumentation/grpc.rb
+++ b/lib/instana/instrumentation/grpc.rb
@@ -45,7 +45,7 @@ end
 if defined?(GRPC::RpcDesc) && ::Instana.config[:grpc][:enabled]
   call_types.each do |call_type|
     GRPC::RpcDesc.class_eval <<-RUBY, __FILE__, __LINE__ + 1
-      def handle_#{call_type}_with_instana(active_call, mth)
+      def handle_#{call_type}_with_instana(active_call, mth, *others)
         kvs = { rpc: {} }
         metadata = active_call.metadata
 
@@ -66,7 +66,7 @@ if defined?(GRPC::RpcDesc) && ::Instana.config[:grpc][:enabled]
           :'rpc-server', kvs, incoming_context
         )
 
-        handle_#{call_type}_without_instana(active_call, mth)
+        handle_#{call_type}_without_instana(active_call, mth, *others)
       rescue => e
         kvs[:rpc][:error] = true
         ::Instana.tracer.log_info(kvs)

--- a/lib/instana/instrumentation/sidekiq-client.rb
+++ b/lib/instana/instrumentation/sidekiq-client.rb
@@ -1,3 +1,4 @@
+require 'byebug'
 module Instana
   module Instrumentation
     class SidekiqClient
@@ -10,8 +11,8 @@ module Instana
 
         # Temporary until we move connection collection to redis
         # instrumentation
-        Sidekiq.redis_pool.with do |conn|
-          opts = conn.client.options
+        Sidekiq.redis_pool.with do |client|
+          opts = client.respond_to?(:connection) ? client.connection : client.client.options
           kv_payload[:'sidekiq-client'][:'redis-url'] = "#{opts[:host]}:#{opts[:port]}"
         end
 

--- a/lib/instana/instrumentation/sidekiq-client.rb
+++ b/lib/instana/instrumentation/sidekiq-client.rb
@@ -1,4 +1,3 @@
-require 'byebug'
 module Instana
   module Instrumentation
     class SidekiqClient

--- a/lib/instana/instrumentation/sidekiq-worker.rb
+++ b/lib/instana/instrumentation/sidekiq-worker.rb
@@ -10,8 +10,8 @@ module Instana
 
         # Temporary until we move connection collection to redis
         # instrumentation
-        Sidekiq.redis_pool.with do |conn|
-          opts = conn.client.options
+        Sidekiq.redis_pool.with do |client|
+          opts = client.respond_to?(:connection) ? client.connection : client.client.options
           kv_payload[:'sidekiq-worker'][:'redis-url'] = "#{opts[:host]}:#{opts[:port]}"
         end
 


### PR DESCRIPTION
Hi @pglombardo,
As you reported, the new redis client version has just changed its interface. This causes some problems:
- It breaks the test of Redis instrumentation (of course). I realize that we don't really need to stub the redis client. I removed all stub and  send invalid command to redis to simulate the cases that redis raises excpetion.
- The sidekiq instrumentation is affected too because we access the redis client via obsoleted interface. The host and port of redis client is now exposed with `connection` method, which is only available in new version. Therefore, I added a check `client.respond_to?(:connection)` to support both old and new interface.

In addition, gRPC gem has just changed the interface of gRPC server, which adds more params into handler method. Therefore, I added a wildcard params to the instrumentation's patch to support future changes. 

Perhaps you'll need some manual tests. Somehow the Instana docker doesn't start on my Macbook, so I could not test on my staging environment. 🤔 

==
Related issues:
- https://github.com/instana/ruby-sensor/issues/102