### PR TITLE
Fix Net HTTP instrumentation closes wrong span

### DIFF
--- a/lib/instana/instrumentation/net-http.rb
+++ b/lib/instana/instrumentation/net-http.rb
@@ -5,6 +5,7 @@ if defined?(::Net::HTTP) && ::Instana.config[:nethttp][:enabled]
 
     def request_with_instana(*args, &block)
       if !Instana.tracer.tracing? || !started?
+        do_skip = true
         return request_without_instana(*args, &block)
       end
 
@@ -54,7 +55,7 @@ if defined?(::Net::HTTP) && ::Instana.config[:nethttp][:enabled]
       ::Instana.tracer.log_error(e)
       raise
     ensure
-      ::Instana.tracer.log_exit(:'net-http', kv_payload)
+      ::Instana.tracer.log_exit(:'net-http', kv_payload) unless do_skip
     end
 
     Instana.logger.info "Instrumenting Net::HTTP"


### PR DESCRIPTION
In ruby's standard HTTP request library, the request method calls itself after starting the request. Therefore, in the instrumentation, the `log_exit` is called twic. Both calls close the current span and mess up the span tree.

![screen shot 2018-01-17 at 11 37 40](https://user-images.githubusercontent.com/11613517/35026036-4ca236a2-fb7b-11e7-8ba4-ab082d8cec61.png)

![screen shot 2018-01-17 at 11 29 07](https://user-images.githubusercontent.com/11613517/35026122-af5154f4-fb7b-11e7-988a-ca4a3a49f9e0.png)
