### PR TITLE
Fail to load rails console in development of MacOS

### DIFF
--- a/instana.gemspec
+++ b/instana.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency('pry', '>= 0.10.0')
   spec.add_development_dependency('pry-byebug', '>= 3.0.0')
 
-  spec.add_runtime_dependency('sys-proctable', '>= 1.1.3')
+  spec.add_runtime_dependency('sys-proctable', '< 1.2.0')
   spec.add_runtime_dependency('get_process_mem', '>= 0.2.1')
   spec.add_runtime_dependency('timers', '>= 4.0.0')
   spec.add_runtime_dependency('oj', '~> 3.3')


### PR DESCRIPTION

```
% bin/rails c
A, [2018-03-20T18:04:01.699610 #19726]   ANY -- : Stan is on the scene.  Starting Instana instrumentation.
W, [2018-03-20T18:04:01.851410 #19726]  WARN -- : Instana: Instrumenting GRPC client
W, [2018-03-20T18:04:01.852351 #19726]  WARN -- : Instana: Instrumenting GRPC server
W, [2018-03-20T18:04:01.853819 #19726]  WARN -- : Instana: Instrumenting Sidekiq client
/Users/rafaelsales/.rbenv/versions/2.3.6/lib/ruby/gems/2.3.0/gems/bundler-1.16.1/lib/bundler/runtime.rb:84:in `rescue in block (2 levels) in require': There was an error while trying to load the gem 'instana'.
Gem Load Error is: wrong number of arguments (given 1, expected 0)
Backtrace for gem load error is:
/Users/rafaelsales/.rbenv/versions/2.3.6/lib/ruby/gems/2.3.0/gems/sys-proctable-1.2.0/lib/darwin/sys/proctable.rb:175:in `ps'
/Users/rafaelsales/.rbenv/versions/2.3.6/lib/ruby/gems/2.3.0/gems/instana-1.7.10/lib/instana/util.rb:143:in `collect_process_info'
/Users/rafaelsales/.rbenv/versions/2.3.6/lib/ruby/gems/2.3.0/gems/instana-1.7.10/lib/instana/agent.rb:60:in `initialize'
/Users/rafaelsales/.rbenv/versions/2.3.6/lib/ruby/gems/2.3.0/gems/instana-1.7.10/lib/instana/base.rb:23:in `new'
/Users/rafaelsales/.rbenv/versions/2.3.6/lib/ruby/gems/2.3.0/gems/instana-1.7.10/lib/instana/base.rb:23:in `setup'
/Users/rafaelsales/.rbenv/versions/2.3.6/lib/ruby/gems/2.3.0/gems/instana-1.7.10/lib/instana/setup.rb:9:in `<top (required)>'
/Users/rafaelsales/.rbenv/versions/2.3.6/lib/ruby/gems/2.3.0/gems/skylight-1.5.1/lib/skylight/probes.rb:81:in `require'
/Users/rafaelsales/.rbenv/versions/2.3.6/lib/ruby/gems/2.3.0/gems/skylight-1.5.1/lib/skylight/probes.rb:81:in `require'
/Users/rafaelsales/.rbenv/versions/2.3.6/lib/ruby/gems/2.3.0/gems/activesupport-5.1.4/lib/active_support/dependencies.rb:292:in `block in require'
/Users/rafaelsales/.rbenv/versions/2.3.6/lib/ruby/gems/2.3.0/gems/activesupport-5.1.4/lib/active_support/dependencies.rb:258:in `load_dependency'
/Users/rafaelsales/.rbenv/versions/2.3.6/lib/ruby/gems/2.3.0/gems/activesupport-5.1.4/lib/active_support/dependencies.rb:292:in `require'
/Users/rafaelsales/.rbenv/versions/2.3.6/lib/ruby/gems/2.3.0/gems/instana-1.7.10/lib/instana.rb:1:in `<top (required)>'
/Users/rafaelsales/.rbenv/versions/2.3.6/lib/ruby/gems/2.3.0/gems/bundler-1.16.1/lib/bundler/runtime.rb:81:in `require'
/Users/rafaelsales/.rbenv/versions/2.3.6/lib/ruby/gems/2.3.0/gems/bundler-1.16.1/lib/bundler/runtime.rb:81:in `block (2 levels) in require'
/Users/rafaelsales/.rbenv/versions/2.3.6/lib/ruby/gems/2.3.0/gems/bundler-1.16.1/lib/bundler/runtime.rb:76:in `each'
/Users/rafaelsales/.rbenv/versions/2.3.6/lib/ruby/gems/2.3.0/gems/bundler-1.16.1/lib/bundler/runtime.rb:76:in `block in require'
/Users/rafaelsales/.rbenv/versions/2.3.6/lib/ruby/gems/2.3.0/gems/bundler-1.16.1/lib/bundler/runtime.rb:65:in `each'
/Users/rafaelsales/.rbenv/versions/2.3.6/lib/ruby/gems/2.3.0/gems/bundler-1.16.1/lib/bundler/runtime.rb:65:in `require'
/Users/rafaelsales/.rbenv/versions/2.3.6/lib/ruby/gems/2.3.0/gems/bundler-1.16.1/lib/bundler.rb:114:in `require'
/Volumes/.../app/config/application.rb:5:in `<top (required)>'
/Users/rafaelsales/.rbenv/versions/2.3.6/lib/ruby/gems/2.3.0/gems/spring-2.0.2/lib/spring/application.rb:92:in `require'
/Users/rafaelsales/.rbenv/versions/2.3.6/lib/ruby/gems/2.3.0/gems/spring-2.0.2/lib/spring/application.rb:92:in `preload'
/Users/rafaelsales/.rbenv/versions/2.3.6/lib/ruby/gems/2.3.0/gems/spring-2.0.2/lib/spring/application.rb:153:in `serve'
/Users/rafaelsales/.rbenv/versions/2.3.6/lib/ruby/gems/2.3.0/gems/spring-2.0.2/lib/spring/application.rb:141:in `block in run'
/Users/rafaelsales/.rbenv/versions/2.3.6/lib/ruby/gems/2.3.0/gems/spring-2.0.2/lib/spring/application.rb:135:in `loop'
/Users/rafaelsales/.rbenv/versions/2.3.6/lib/ruby/gems/2.3.0/gems/spring-2.0.2/lib/spring/application.rb:135:in `run'
/Users/rafaelsales/.rbenv/versions/2.3.6/lib/ruby/gems/2.3.0/gems/spring-2.0.2/lib/spring/application/boot.rb:19:in `<top (required)>'
/Users/rafaelsales/.rbenv/versions/2.3.6/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
/Users/rafaelsales/.rbenv/versions/2.3.6/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
-e:1:in `<main>'
Bundler Error Backtrace:
 (Bundler::GemRequireError)
        from /Users/rafaelsales/.rbenv/versions/2.3.6/lib/ruby/gems/2.3.0/gems/bundler-1.16.1/lib/bundler/runtime.rb:80:in `block (2 levels) in require'
        from /Users/rafaelsales/.rbenv/versions/2.3.6/lib/ruby/gems/2.3.0/gems/bundler-1.16.1/lib/bundler/runtime.rb:76:in `each'
        from /Users/rafaelsales/.rbenv/versions/2.3.6/lib/ruby/gems/2.3.0/gems/bundler-1.16.1/lib/bundler/runtime.rb:76:in `block in require'
        from /Users/rafaelsales/.rbenv/versions/2.3.6/lib/ruby/gems/2.3.0/gems/bundler-1.16.1/lib/bundler/runtime.rb:65:in `each'
        from /Users/rafaelsales/.rbenv/versions/2.3.6/lib/ruby/gems/2.3.0/gems/bundler-1.16.1/lib/bundler/runtime.rb:65:in `require'
        from /Users/rafaelsales/.rbenv/versions/2.3.6/lib/ruby/gems/2.3.0/gems/bundler-1.16.1/lib/bundler.rb:114:in `require'
        from /Volumes/.../app/config/application.rb:5:in `<top (required)>'
        from /Users/rafaelsales/.rbenv/versions/2.3.6/lib/ruby/gems/2.3.0/gems/spring-2.0.2/lib/spring/application.rb:92:in `require'
        from /Users/rafaelsales/.rbenv/versions/2.3.6/lib/ruby/gems/2.3.0/gems/spring-2.0.2/lib/spring/application.rb:92:in `preload'
        from /Users/rafaelsales/.rbenv/versions/2.3.6/lib/ruby/gems/2.3.0/gems/spring-2.0.2/lib/spring/application.rb:153:in `serve'
        from /Users/rafaelsales/.rbenv/versions/2.3.6/lib/ruby/gems/2.3.0/gems/spring-2.0.2/lib/spring/application.rb:141:in `block in run'
        from /Users/rafaelsales/.rbenv/versions/2.3.6/lib/ruby/gems/2.3.0/gems/spring-2.0.2/lib/spring/application.rb:135:in `loop'
        from /Users/rafaelsales/.rbenv/versions/2.3.6/lib/ruby/gems/2.3.0/gems/spring-2.0.2/lib/spring/application.rb:135:in `run'
        from /Users/rafaelsales/.rbenv/versions/2.3.6/lib/ruby/gems/2.3.0/gems/spring-2.0.2/lib/spring/application/boot.rb:19:in `<top (required)>'
        from /Users/rafaelsales/.rbenv/versions/2.3.6/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /Users/rafaelsales/.rbenv/versions/2.3.6/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from -e:1:in `<main>'
```

**Gemfile.lock**:
```
    instana (1.7.10)
      ffi (>= 1.8.1)
      get_process_mem (>= 0.2.1)
      oj (~> 3.3)
      sys-proctable (>= 1.1.3)
      timers (>= 4.0.0)
    ffi (1.9.18)
    get_process_mem (0.2.1)
    oj (3.5.0)
    sys-proctable (1.2.0)
      ffi
    timers (4.1.2)
      hitimes
```
