### PR TITLE
Can't turn off warnings in console

### DIFF
--- a/lib/instana/agent.rb
+++ b/lib/instana/agent.rb
@@ -118,7 +118,7 @@ module Instana
         if @state == :unannounced
           if host_agent_ready? && announce_sensor
             transition_to(:announced)
-            ::Instana.logger.warn "Host agent available. We're in business. (#{@state} pid:#{Process.pid} #{@process[:name]})"
+            ::Instana.logger.info "Host agent available. We're in business. (#{@state} pid:#{Process.pid} #{@process[:name]})"
           end
         end
       end

--- a/lib/instana/instrumentation/grpc.rb
+++ b/lib/instana/instrumentation/grpc.rb
@@ -39,7 +39,7 @@ if defined?(GRPC::ActiveCall) && ::Instana.config[:grpc][:enabled]
       alias #{call_type} #{call_type}_with_instana
     RUBY
   end
-  ::Instana.logger.warn 'Instrumenting GRPC client'
+  ::Instana.logger.info 'Instrumenting GRPC client'
 end
 
 if defined?(GRPC::RpcDesc) && ::Instana.config[:grpc][:enabled]
@@ -80,5 +80,5 @@ if defined?(GRPC::RpcDesc) && ::Instana.config[:grpc][:enabled]
       alias handle_#{call_type} handle_#{call_type}_with_instana
     RUBY
   end
-  ::Instana.logger.warn 'Instrumenting GRPC server'
+  ::Instana.logger.info 'Instrumenting GRPC server'
 end

--- a/lib/instana/instrumentation/sidekiq-client.rb
+++ b/lib/instana/instrumentation/sidekiq-client.rb
@@ -38,7 +38,7 @@ end
 if defined?(::Sidekiq) && ::Instana.config[:'sidekiq-client'][:enabled]
   ::Sidekiq.configure_client do |cfg|
     cfg.client_middleware do |chain|
-      ::Instana.logger.warn "Instrumenting Sidekiq client"
+      ::Instana.logger.info "Instrumenting Sidekiq client"
       chain.add ::Instana::Instrumentation::SidekiqClient
     end
   end

--- a/lib/instana/instrumentation/sidekiq-worker.rb
+++ b/lib/instana/instrumentation/sidekiq-worker.rb
@@ -43,7 +43,7 @@ end
 if defined?(::Sidekiq) && ::Instana.config[:'sidekiq-worker'][:enabled]
   ::Sidekiq.configure_server do |cfg|
     cfg.server_middleware do |chain|
-      ::Instana.logger.warn "Instrumenting Sidekiq worker"
+      ::Instana.logger.info "Instrumenting Sidekiq worker"
       chain.add ::Instana::Instrumentation::SidekiqWorker
     end
   end


### PR DESCRIPTION
When I open rails console in my app, I get the following log entries in the STDOUT:

```
A, [2018-03-20T18:12:26.973106 #20062]   ANY -- : Stan is on the scene.  Starting Instana instrumentation.
W, [2018-03-20T18:12:27.104292 #20062]  WARN -- : Instana: Instrumenting GRPC client
W, [2018-03-20T18:12:27.105319 #20062]  WARN -- : Instana: Instrumenting GRPC server
W, [2018-03-20T18:12:27.106867 #20062]  WARN -- : Instana: Instrumenting Sidekiq client
```

I see a couple of issues here:
- These are not legit warnings, as there's nothing to fix. These should either be INFO or DEBUG.
- Customizing `::Instana.logger` on rails initializer didn't affect the log lines on app load
- Customizing `::Instana.logger.level = ::Logger::ERROR` on rails initializer didn't affect the log lines on app load #