### PR TITLE
Update sys-proctable API call to follow upstream changes

### DIFF
--- a/instana.gemspec
+++ b/instana.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency('pry', '>= 0.10.0')
   spec.add_development_dependency('pry-byebug', '>= 3.0.0')
 
-  spec.add_runtime_dependency('sys-proctable', '< 1.2.0')
+  spec.add_runtime_dependency('sys-proctable', '>= 1.2.0')
   spec.add_runtime_dependency('get_process_mem', '>= 0.2.1')
   spec.add_runtime_dependency('timers', '>= 4.0.0')
   spec.add_runtime_dependency('oj', '~> 3.3')

--- a/lib/instana/util.rb
+++ b/lib/instana/util.rb
@@ -140,7 +140,7 @@ module Instana
         if File.exist?(cmdline_file)
           cmdline = IO.read(cmdline_file).split(?\x00)
         else
-          cmdline = ProcTable.ps(Process.pid).cmdline.split(' ')
+          cmdline = ProcTable.ps(:pid => Process.pid).cmdline.split(' ')
         end
 
         if RUBY_PLATFORM =~ /darwin/i


### PR DESCRIPTION
sys-proctable (used on OSX platforms only) changed the argument in `Proctable.ps` to a keyword argument which was a breaking change.

This PR updates the call and raised the dependency to be 1.2.0 or greater.