### PR TITLE
Replace Oj with JSON

### DIFF
--- a/instana.gemspec
+++ b/instana.gemspec
@@ -35,7 +35,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency('sys-proctable', '>= 1.2.0')
   spec.add_runtime_dependency('get_process_mem', '>= 0.2.1')
   spec.add_runtime_dependency('timers', '>= 4.0.0')
-  spec.add_runtime_dependency('oj', '~> 3.3')
 
   # Indirect dependency
   # https://github.com/instana/ruby-sensor/issues/10

--- a/lib/instana/agent.rb
+++ b/lib/instana/agent.rb
@@ -1,4 +1,4 @@
-require 'oj'
+require 'json'
 require 'net/http'
 require 'socket'
 require 'sys/proctable'
@@ -7,7 +7,7 @@ require 'uri'
 require 'thread'
 include Sys
 
-Oj.default_options = {:mode => :strict}
+# JSON.default_options = {:mode => :strict}
 
 module Instana
   class Agent
@@ -211,14 +211,14 @@ module Instana
 
       uri = URI.parse("http://#{@discovered[:agent_host]}:#{@discovered[:agent_port]}/#{DISCOVERY_PATH}")
       req = Net::HTTP::Put.new(uri)
-      req.body = Oj.dump(announce_payload)
+      req.body = JSON.dump(announce_payload)
 
       ::Instana.logger.debug "Announce: http://#{@discovered[:agent_host]}:#{@discovered[:agent_port]}/#{DISCOVERY_PATH} - payload: #{req.body}"
 
       response = make_host_agent_request(req)
 
       if response && (response.code.to_i == 200)
-        data = Oj.load(response.body)
+        data = JSON.load(response.body)
         @process[:report_pid] = data['pid']
         @agent_uuid = data['agentUuid']
         true
@@ -249,7 +249,7 @@ module Instana
       uri = URI.parse("http://#{@discovered[:agent_host]}:#{@discovered[:agent_port]}/#{path}")
       req = Net::HTTP::Post.new(uri)
 
-      req.body = Oj.dump(payload)
+      req.body = JSON.dump(payload)
       response = make_host_agent_request(req)
 
       if response
@@ -277,7 +277,7 @@ module Instana
     # @param json_string [String] the requests from the host agent
     #
     def handle_agent_tasks(json_string)
-      tasks = Oj.load(json_string)
+      tasks = JSON.load(json_string)
 
       if tasks.is_a?(Hash)
         process_agent_task(tasks)
@@ -306,7 +306,7 @@ module Instana
       path = "com.instana.plugin.ruby/response.#{@process[:report_pid]}?messageId=#{URI.encode(task['messageId'])}"
       uri = URI.parse("http://#{@discovered[:agent_host]}:#{@discovered[:agent_port]}/#{path}")
       req = Net::HTTP::Post.new(uri)
-      req.body = Oj.dump(payload)
+      req.body = JSON.dump(payload)
       ::Instana.logger.debug "Responding to agent request: #{req.inspect}"
       make_host_agent_request(req)
 
@@ -332,7 +332,7 @@ module Instana
       uri = URI.parse("http://#{@discovered[:agent_host]}:#{@discovered[:agent_port]}/#{path}")
       req = Net::HTTP::Post.new(uri)
 
-      req.body = Oj.dump(spans)
+      req.body = JSON.dump(spans)
       response = make_host_agent_request(req)
 
       if response

--- a/test/agent/agent_test.rb
+++ b/test/agent/agent_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
-require 'oj'
+require 'json'
 
-Oj.default_options = {:mode => :strict}
+# JSON.default_options = {:mode => :strict}
 
 class AgentTest < Minitest::Test
   def test_agent_host_detection
@@ -68,7 +68,7 @@ class AgentTest < Minitest::Test
     ::Instana.agent.instance_variable_set(:@discovered, discovery)
 
     url = "http://#{::Instana.config[:agent_host]}:#{::Instana.config[:agent_port]}/com.instana.plugin.ruby.discovery"
-    json = Oj.dump({ 'pid' => Process.pid, 'agentUuid' => 'abc' })
+    json = JSON.dump({ 'pid' => Process.pid, 'agentUuid' => 'abc' })
     stub_request(:put, url).to_return(:body => json, :status => 200)
 
     assert_equal true, ::Instana.agent.announce_sensor
@@ -95,7 +95,7 @@ class AgentTest < Minitest::Test
     ::Instana.agent.instance_variable_set(:@discovered, discovery)
 
     url = "http://#{::Instana.config[:agent_host]}:#{::Instana.config[:agent_port]}/com.instana.plugin.ruby.discovery"
-    json = Oj.dump({ 'pid' => Process.pid, 'agentUuid' => 'abc' })
+    json = JSON.dump({ 'pid' => Process.pid, 'agentUuid' => 'abc' })
     stub_request(:put, url).to_return(:body => json, :status => 200)
     ::Instana.agent.announce_sensor
 


### PR DESCRIPTION
Tests are passing.

```
I, [2018-08-21T11:53:21.943181 #62856]  INFO -- : Instana: Stan is on the scene.  Starting Instana instrumentation version 1.7.14
I, [2018-08-21T11:53:21.981809 #62856]  INFO -- : Instana: Instrumenting Net::HTTP
D, [2018-08-21T11:53:21.995257 #62856] DEBUG -- : Instana: run_discovery: Running agent discovery...
D, [2018-08-21T11:53:21.995428 #62856] DEBUG -- : Instana: run_discovery: Trying 127.0.0.1:42699
D, [2018-08-21T11:53:21.997383 #62856] DEBUG -- : Instana: Adding Instana::Collectors::GC to collectors...
D, [2018-08-21T11:53:22.001303 #62856] DEBUG -- : Instana: Adding Instana::Collectors::Memory to collectors...
D, [2018-08-21T11:53:22.002361 #62856] DEBUG -- : Instana: Adding Instana::Collectors::Thread to collectors...
D, [2018-08-21T11:53:22.004060 #62856] DEBUG -- : Instana: run_discovery: Running agent discovery...
D, [2018-08-21T11:53:22.004253 #62856] DEBUG -- : Instana: run_discovery: Trying 127.0.0.1:42699
W, [2018-08-21T11:53:22.005397 #62856]  WARN -- : Instana: Host agent not available.  Will retry periodically. (Set env INSTANA_QUIET=1 to shut these messages off)
W, [2018-08-21T11:53:22.013676 #62856]  WARN -- : Instana: Database connect string configured to: mysql2://root:@127.0.0.1:3306/travis_ci_test
I, [2018-08-21T11:53:22.016658 #62856]  INFO -- : Instana: Booting instrumented background Rackapp on port 6511 for tests.
Puma starting in single mode...
* Version 3.12.0 (ruby 2.5.0-p0), codename: Llamas in Pajamas
* Min threads: 0, max threads: 16
* Environment: development
* Listening on tcp://127.0.0.1:6511
Use Ctrl-C to stop
Started with run options --seed 38808

CustomTracingTest
D, [2018-08-21T11:53:24.062279 #62856] DEBUG -- : Instana: Span mismatch: Attempt to end rack span but custom_trace is active.
  test_custom_tracing                                             PASS (0.00s)
  test_custom_tracing_with_args                                   PASS (0.00s)
  test_custom_tracing_with_error                                  PASS (0.00s)

BenchIDs
bench_generate_id	 0.234126	 0.231947	 0.231765	 0.245721	 0.231850
  bench_generate_id                                               PASS (1.22s)

AgentTest
D, [2018-08-21T11:53:25.288277 #62856] DEBUG -- : Instana: run_discovery: Running agent discovery...
D, [2018-08-21T11:53:25.288380 #62856] DEBUG -- : Instana: run_discovery: Trying 172.0.12.100:12829
D, [2018-08-21T11:53:25.288924 #62856] DEBUG -- : Instana: run_discovery: Found 172.0.12.100:12829
  test_custom_configure_agent                                     PASS (0.00s)
D, [2018-08-21T11:53:25.289461 #62856] DEBUG -- : Instana: run_discovery: Running agent discovery...
D, [2018-08-21T11:53:25.289521 #62856] DEBUG -- : Instana: run_discovery: Trying 127.0.0.1:42699
D, [2018-08-21T11:53:25.290021 #62856] DEBUG -- : Instana: run_discovery: Found 127.0.0.1:42699
  test_successful_discovery                                       PASS (0.00s)
D, [2018-08-21T11:53:25.292140 #62856] DEBUG -- : Instana: Announce: http://127.0.0.1:42699/com.instana.plugin.ruby.discovery - payload: {"pid":62856,"name":"puma 3.12.0 (tcp://127.0.0.1:6511) [ruby-sensor]","args":null}
  test_announce_sensor                                            PASS (0.00s)
D, [2018-08-21T11:53:25.294109 #62856] DEBUG -- : Instana: Announce: http://127.0.0.1:42699/com.instana.plugin.ruby.discovery - payload: {"pid":62856,"name":"puma 3.12.0 (tcp://127.0.0.1:6511) [ruby-sensor]","args":null}
  test_failed_metric_report                                       PASS (0.00s)
D, [2018-08-21T11:53:25.296231 #62856] DEBUG -- : Instana: Announce: http://127.0.0.1:42699/com.instana.plugin.ruby.discovery - payload: {"pid":62856,"name":"puma 3.12.0 (tcp://127.0.0.1:6511) [ruby-sensor]","args":null}
  test_metric_report                                              PASS (0.00s)
D, [2018-08-21T11:53:25.298311 #62856] DEBUG -- : Instana: Announce: http://127.0.0.1:42699/com.instana.plugin.ruby.discovery - payload: {"pid":62856,"name":"puma 3.12.0 (tcp://127.0.0.1:6511) [ruby-sensor]","args":null}
  test_failed_announce_sensor                                     PASS (0.00s)
  test_agent_host_detection                                       PASS (0.00s)
D, [2018-08-21T11:53:25.300142 #62856] DEBUG -- : Instana: make_host_agent_request:agent.rb:502: execution expired
  test_agent_timeout                                              PASS (0.00s)
  test_no_host_agent                                              PASS (0.00s)
D, [2018-08-21T11:53:25.301007 #62856] DEBUG -- : Instana: run_discovery: Running agent discovery...
D, [2018-08-21T11:53:25.301055 #62856] DEBUG -- : Instana: run_discovery: Trying 127.0.0.1:42699
  test_failed_discovery                                           PASS (0.00s)

BenchOpenTracing
bench_start_finish_span	 0.177962	 0.155152	 0.161627	 0.169534	 0.145377
  bench_start_finish_span                                         PASS (1.01s)

TracerAsyncTest
D, [2018-08-21T11:53:26.315198 #62856] DEBUG -- : Instana: Staging incomplete trace id: 1048018274964019504
  test_never_ending_async                                         PASS (0.51s)
  test_same_thread_async_tracing                                  PASS (0.00s)
D, [2018-08-21T11:53:26.817957 #62856] DEBUG -- : Instana: Staging incomplete trace id: -1445194186170447112
D, [2018-08-21T11:53:26.818023 #62856] DEBUG -- : Instana: Moving staged complete trace to main queue: -1445194186170447112
  test_out_of_order_async_tracing                                 PASS (0.00s)
D, [2018-08-21T11:53:26.818188 #62856] DEBUG -- : Instana: Staging incomplete trace id: 1562736881040992091
D, [2018-08-21T11:53:27.322132 #62856] DEBUG -- : Instana: Moving staged complete trace to main queue: 1562736881040992091
  test_staged_trace_moved_to_queue                                PASS (0.50s)
  test_diff_thread_async_tracing                                  PASS (1.01s)

TraceTest
  test_min_value_of_generated_id                                  PASS (0.00s)
  test_exit_span_has_stack_by_config                              PASS (0.00s)
  test_entry_span_doesnt_have_stack_by_default                    PASS (0.00s)
  test_max_value_of_generated_id                                  PASS (0.00s)
  test_exit_span_doesnt_have_stack_by_default                     PASS (0.00s)
  test_trace_spans_count                                          PASS (0.00s)
  test_trace_with_incoming_context                                PASS (0.00s)
  test_entry_span_has_stack_by_config                             PASS (0.00s)

TracerIDMgmtTest
  test_id_conversion_back_and_forth                               PASS (0.04s)
  test_id_max_value_and_conversion                                PASS (0.00s)
D, [2018-08-21T11:53:28.380471 #62856] DEBUG -- : Instana: id_to_header received a NilClass: returning empty string
D, [2018-08-21T11:53:28.380510 #62856] DEBUG -- : Instana: id_to_header received a Array: returning empty string
  test_id_to_header_conversion_with_bogus_id                      PASS (0.00s)
D, [2018-08-21T11:53:28.380577 #62856] DEBUG -- : Instana: header_to_id received a NilClass: returning 0
D, [2018-08-21T11:53:28.380597 #62856] DEBUG -- : Instana: header_to_id received a Integer: returning 0
D, [2018-08-21T11:53:28.380611 #62856] DEBUG -- : Instana: header_to_id received a Array: returning 0
  test_header_to_id_conversion_with_bogus_header                  PASS (0.00s)
  test_that_leading_zeros_handled_correctly                       PASS (0.00s)
  test_header_to_id_conversion                                    PASS (0.00s)
  test_id_to_header_conversion                                    PASS (0.00s)

TracerTest
  test_basic_trace_block                                          PASS (0.10s)
  test_low_level_error_logging                                    PASS (0.00s)
  test_obey_tracing_config                                        PASS (0.00s)
  test_errors_are_properly_propagated                             PASS (0.00s)
  test_that_it_has_a_valid_tracer                                 PASS (0.00s)
  test_block_tracing_error_capture                                PASS (0.00s)
  test_complex_trace_block                                        PASS (0.41s)
  test_complex_low_level_tracing                                  PASS (0.00s)
  test_instana_headers_in_response                                PASS (0.50s)
  test_basic_low_level_tracing                                    PASS (0.00s)

OpenTracerTest
  test_start_span_with_tags                                       PASS (0.00s)
  test_nested_spans_with_baggage                                  PASS (0.10s)
  test_span_kind_translation                                      PASS (0.00s)
  test_baggage_with_complex_data                                  PASS (0.10s)
  test_start_span_with_baggage                                    PASS (0.00s)
  test_get_with_inject_extract                                    PASS (0.02s)
  test_nested_spans_using_child_of                                PASS (0.10s)
  test_basic_get_with_opentracing                                 PASS (0.00s)
  test_context_should_carry_baggage                               PASS (0.10s)
  test_supplies_all_ot_interfaces                                 PASS (0.00s)
  test_start_span_with_custom_start_time                          PASS (0.00s)
  test_start_span_with_nested_spans                               PASS (0.10s)
  test_start_span_with_timestamps                                 PASS (0.11s)

Finished in 5.97554s
58 tests, 12447 assertions, 0 failures, 0 errors, 0 skips
```