### PR TITLE
Add Safety and avoid triggering DB connections when unknown adapter

### DIFF
--- a/lib/instana/agent.rb
+++ b/lib/instana/agent.rb
@@ -46,7 +46,7 @@ module Instana
 
       # In case we're running in Docker, have the default gateway available
       # to check in case we're running in bridged network mode
-      if @is_linux
+      if @is_linux && File.exist?("/sbin/ip")
         @default_gateway = `/sbin/ip route | awk '/default/ { print $3 }'`.chomp
       else
         @default_gateway = nil

--- a/lib/instana/frameworks/instrumentation/active_record.rb
+++ b/lib/instana/frameworks/instrumentation/active_record.rb
@@ -23,6 +23,6 @@ if defined?(::ActiveRecord) && ::Instana.config[:active_record][:enabled]
     ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.send(:include, ::Instana::Instrumentation::PostgreSQLAdapter)
 
   else
-    ::Instana.logger.debug "Unsupported ActiveRecord adapter: #{ActiveRecord::Base.connection.adapter_name.downcase}"
+    ::Instana.logger.debug "Unsupported ActiveRecord adapter"
   end
 end


### PR DESCRIPTION
* When unknown adapter, don't reference adapter name as it triggers a db connection
* Make sure binary exists before executing.