### PR TITLE
Better Rails initialization

### DIFF
--- a/lib/instana/frameworks/rails.rb
+++ b/lib/instana/frameworks/rails.rb
@@ -1,26 +1,40 @@
 require "instana/rack"
 
 if defined?(::Rails)
-  # In Rails, let's use the Rails logger
-  ::Instana.logger = ::Rails.logger if ::Rails.logger
 
   if ::Rails::VERSION::MAJOR < 3
     ::Rails.configuration.after_initialize do
-      ::Instana.logger.info "Instrumenting Rack"
-      ::Rails.configuration.middleware.insert 0, ::Instana::Rack
+      # In Rails, let's use the Rails logger
+      ::Instana.logger = ::Rails.logger if ::Rails.logger
+
+      if ::Instana.config[:tracing][:enabled]
+        ::Instana.logger.info "Instrumenting Rack"
+        ::Rails.configuration.middleware.insert 0, ::Instana::Rack
+      else
+        ::Instana.logger.info "Rack: Tracing disabled via config.  Not enabling middleware."
+      end
     end
   else
     module ::Instana
       class Railtie < ::Rails::Railtie
         initializer 'instana.rack' do |app|
-          ::Instana.logger.info "Instrumenting Rack"
-          app.config.middleware.insert 0, ::Instana::Rack
+          # In Rails, let's use the Rails logger
+          ::Instana.logger = ::Rails.logger if ::Rails.logger
+
+          if ::Instana.config[:tracing][:enabled]
+            ::Instana.logger.info "Instrumenting Rack"
+            app.config.middleware.insert 0, ::Instana::Rack
+          else
+            ::Instana.logger.info "Rack: Tracing disabled via config.  Not enabling middleware."
+          end
         end
 
-        config.after_initialize do
-          require "instana/frameworks/instrumentation/active_record"
-          require "instana/frameworks/instrumentation/action_controller"
-          require "instana/frameworks/instrumentation/action_view"
+        if ::Instana.config[:tracing][:enabled]
+          config.after_initialize do
+            require "instana/frameworks/instrumentation/active_record"
+            require "instana/frameworks/instrumentation/action_controller"
+            require "instana/frameworks/instrumentation/action_view"
+          end
         end
       end
     end


### PR DESCRIPTION
* Honor the `::Instana.config[:tracing][:enabled]` config
* Inherit the Rails logger later in the boot process