### PR TITLE
Pass OJ options in to dump/load calls instead of setting them as defa…

### DIFF
--- a/lib/instana/agent.rb
+++ b/lib/instana/agent.rb
@@ -12,9 +12,9 @@ require 'instana/agent/tasks'
 
 include Sys
 
-Oj.default_options = {:mode => :strict}
-
 module Instana
+  OJ_OPTIONS = {:mode => :strict}
+
   class Agent
     include AgentHelpers
     include AgentHooks
@@ -209,14 +209,14 @@ module Instana
 
       uri = URI.parse("http://#{@discovered[:agent_host]}:#{@discovered[:agent_port]}/#{DISCOVERY_PATH}")
       req = Net::HTTP::Put.new(uri)
-      req.body = Oj.dump(announce_payload)
+      req.body = Oj.dump(announce_payload, OJ_OPTIONS)
 
       ::Instana.logger.debug "Announce: http://#{@discovered[:agent_host]}:#{@discovered[:agent_port]}/#{DISCOVERY_PATH} - payload: #{req.body}"
 
       response = make_host_agent_request(req)
 
       if response && (response.code.to_i == 200)
-        data = Oj.load(response.body)
+        data = Oj.load(response.body, OJ_OPTIONS)
         @process[:report_pid] = data['pid']
         @agent_uuid = data['agentUuid']
 
@@ -251,7 +251,7 @@ module Instana
       uri = URI.parse("http://#{@discovered[:agent_host]}:#{@discovered[:agent_port]}/#{path}")
       req = Net::HTTP::Post.new(uri)
 
-      req.body = Oj.dump(payload)
+      req.body = Oj.dump(payload, OJ_OPTIONS)
       response = make_host_agent_request(req)
 
       if response
@@ -290,7 +290,9 @@ module Instana
       uri = URI.parse("http://#{@discovered[:agent_host]}:#{@discovered[:agent_port]}/#{path}")
       req = Net::HTTP::Post.new(uri)
 
-      req.body = Oj.dump(spans, :omit_nil => true)
+      opts = OJ_OPTIONS.merge({omit_nil: true})
+
+      req.body = Oj.dump(spans, opts)
       response = make_host_agent_request(req)
 
       if response

--- a/lib/instana/agent/tasks.rb
+++ b/lib/instana/agent/tasks.rb
@@ -4,8 +4,11 @@ module AgentTasks
   #
   # @param json_string [String] the requests from the host agent
   #
+
+  OJ_OPTIONS = {mode: :strict}
+
   def handle_agent_tasks(json_string)
-    tasks = Oj.load(json_string)
+    tasks = Oj.load(json_string, OJ_OPTIONS)
 
     if tasks.is_a?(Hash)
       process_agent_task(tasks)
@@ -34,7 +37,7 @@ module AgentTasks
     path = "com.instana.plugin.ruby/response.#{@process[:report_pid]}?messageId=#{URI.encode(task['messageId'])}"
     uri = URI.parse("http://#{@discovered[:agent_host]}:#{@discovered[:agent_port]}/#{path}")
     req = Net::HTTP::Post.new(uri)
-    req.body = Oj.dump(payload)
+    req.body = Oj.dump(payload, OJ_OPTIONS)
     ::Instana.logger.debug "Responding to agent request: #{req.inspect}"
     make_host_agent_request(req)
 

--- a/test/agent/agent_test.rb
+++ b/test/agent/agent_test.rb
@@ -1,8 +1,6 @@
 require 'test_helper'
 require 'oj'
 
-Oj.default_options = {:mode => :strict}
-
 class AgentTest < Minitest::Test
   def test_agent_host_detection
     url = "http://#{::Instana.config[:agent_host]}:#{::Instana.config[:agent_port]}/"


### PR DESCRIPTION
…ults.

I ran into an issue adding the instana gem to an existing system which was also using OJ, but without requiring strict mode set. This seems like something maybe the agent doesn't necessarily want to set system-wide, but only for its own calls to OJ?

I'm pretty out-of-practice with Ruby, so not sure if a module constant is the right thing to do here?