### PR TITLE
Respect custom service name in in traces

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ cache:
     - vendor/bundle
 
 rvm:
-  - 2.4.3
-  - 2.1.10
+  - 2.5
+  - 2.4
 
 before_install:
   # Re: https://docs.travis-ci.com/user/languages/ruby/#dependency-management

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,9 @@ rvm:
   - 2.1.10
 
 before_install:
-  - gem update --system
-  - gem update bundler
-  - gem --version
+  # Re: https://docs.travis-ci.com/user/languages/ruby/#dependency-management
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v '< 2'  - gem --version
 
 before_script:
   - psql -c 'create database travis_ci_test;' -U postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ rvm:
 before_install:
   # Re: https://docs.travis-ci.com/user/languages/ruby/#dependency-management
   - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
-  - gem install bundler -v '< 2'  - gem --version
+  - gem install bundler -v '< 2'
+  - gem --version
 
 before_script:
   - psql -c 'create database travis_ci_test;' -U postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,16 +31,12 @@ gemfile:
   - gemfiles/libraries.gemfile
   - gemfiles/rails50.gemfile
   - gemfiles/rails42.gemfile
-  - gemfiles/rails32.gemfile
 
 matrix:
   exclude:
     # Rails 5.0+ requires Ruby 2.2.2 or higher
     - rvm: 2.1.10
       gemfile: gemfiles/rails50.gemfile
-    # Rails 3.2 doesn't work on Ruby 2.4.1
-    - rvm: 2.4.3
-      gemfile: gemfiles/rails32.gemfile
 
 notifications:
   slack:

--- a/lib/instana/instrumentation/rack.rb
+++ b/lib/instana/instrumentation/rack.rb
@@ -19,6 +19,10 @@ module Instana
         kvs[:http][:host] = env['SERVER_NAME']
       end
 
+      if ENV.key?('INSTANA_SERVICE_NAME')
+        kvs[:service] = ENV['INSTANA_SERVICE_NAME']
+      end
+
       if ::Instana.agent.extra_headers
         for custom_header in ::Instana.agent.extra_headers
           # Headers are available in this format: HTTP_X_CAPTURE_THIS

--- a/lib/instana/instrumentation/sidekiq-worker.rb
+++ b/lib/instana/instrumentation/sidekiq-worker.rb
@@ -15,6 +15,10 @@ module Instana
           kv_payload[:'sidekiq-worker'][:'redis-url'] = "#{opts[:host]}:#{opts[:port]}"
         end
 
+        if ENV.key?('INSTANA_SERVICE_NAME')
+          kv_payload[:service] = ENV['INSTANA_SERVICE_NAME']
+        end
+
         context = {}
         if msg.key?('X-Instana-T')
           trace_id = msg.delete('X-Instana-T')

--- a/test/frameworks/rack_test.rb
+++ b/test/frameworks/rack_test.rb
@@ -47,6 +47,24 @@ class RackTest < Minitest::Test
     refute_nil first_span[:stack].first[:f].match(/instana\/instrumentation\/rack.rb/)
   end
 
+  def test_basic_get_with_custom_service_name
+    ENV['INSTANA_SERVICE_NAME'] = 'WalterBishop'
+
+    clear_all!
+    get '/mrlobster'
+    assert last_response.ok?
+
+    spans = ::Instana.processor.queued_spans
+
+    # Span validation
+    assert_equal 1, spans.count
+
+    first_span = spans.first
+    assert_equal 'WalterBishop', first_span[:data][:service]
+
+    ENV.delete('INSTANA_SERVICE_NAME')
+  end
+
   def test_basic_post
     clear_all!
     post '/mrlobster'


### PR DESCRIPTION
When the environment variable `INSTANA_SERVICE_NAME` is set, it names the process entity but it should also assure that this service name takes priority for reported traces.