### PR TITLE
Allow unsetting of INSTANA_DISABLE_AUTO_INSTR environment var

### DIFF
--- a/lib/instana/instrumentation.rb
+++ b/lib/instana/instrumentation.rb
@@ -3,7 +3,7 @@ module Instana
 end
 
 
-if !ENV.key?('INSTANA_DISABLE_AUTO_INSTR')
+if !ENV.key?('INSTANA_DISABLE_AUTO_INSTR') || ENV['INSTANA_DISABLE_AUTO_INSTR'] === 'false'
   #
   # Load all of the files in the specified subdirectories
   #


### PR DESCRIPTION
Currently if this key is set, all instrumentation is disabled, which is hard in some environments. This allows you to set this value to false to disable the disable.