### PR TITLE
Fix error in action controller has rails handler

### DIFF
--- a/lib/instana/frameworks/instrumentation/action_controller.rb
+++ b/lib/instana/frameworks/instrumentation/action_controller.rb
@@ -21,7 +21,7 @@ module Instana
         end
         found
       rescue => e
-        ::Instana.logger.debug "#{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}"
+        ::Instana.logger.debug { "#{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}" }
         return false
       end
 

--- a/lib/instana/frameworks/instrumentation/action_controller.rb
+++ b/lib/instana/frameworks/instrumentation/action_controller.rb
@@ -11,7 +11,7 @@ module Instana
       #
       # @return [Boolean]
       #
-      def has_rails_handler?
+      def has_rails_handler?(exception)
         found = false
         rescue_handlers.detect do |klass_name, _handler|
           # Rescue handlers can be specified as strings or constant names
@@ -72,7 +72,7 @@ module Instana
 
         super(*args)
       rescue Exception => e
-        ::Instana.tracer.log_error(e) unless has_rails_handler?
+        ::Instana.tracer.log_error(e) unless has_rails_handler?(e)
         raise
       ensure
         ::Instana.tracer.log_exit(:actioncontroller)
@@ -92,7 +92,7 @@ module Instana
 
         super(*args, &blk)
       rescue Exception => e
-        ::Instana.tracer.log_error(e) unless has_rails_handler?
+        ::Instana.tracer.log_error(e) unless has_rails_handler?(e)
         raise
       ensure
         ::Instana.tracer.log_exit(:actionview)
@@ -124,7 +124,7 @@ module Instana
 
         process_action_without_instana(*args)
       rescue Exception => e
-        ::Instana.tracer.log_error(e) unless has_rails_handler?
+        ::Instana.tracer.log_error(e) unless has_rails_handler?(e)
         raise
       ensure
         ::Instana.tracer.log_exit(:actioncontroller)
@@ -141,7 +141,7 @@ module Instana
         ::Instana.tracer.log_entry(:actionview, :actionview => { :name => name })
         render_without_instana(*args, &blk)
       rescue Exception => e
-        ::Instana.tracer.log_error(e) unless has_rails_handler?
+        ::Instana.tracer.log_error(e) unless has_rails_handler?(e)
         raise
       ensure
         ::Instana.tracer.log_exit(:actionview)


### PR DESCRIPTION
We were noticing `NoMethodError`s being raised from [this line](https://github.com/instana/ruby-sensor/blob/1.9.5/lib/instana/frameworks/instrumentation/action_controller.rb#L20
). It looks like `has_rails_handler?` should have `exception` as an argument.

Also, this updates a call to `Instana.logger.debug` to build its log message within a block. This makes it so that we don't have to build the log message if our log level isn't `debug`.
