### PR TITLE
Rails: Support case of multiple ActiveRecord adapters

### DIFF
--- a/lib/instana/frameworks/instrumentation/abstract_mysql_adapter.rb
+++ b/lib/instana/frameworks/instrumentation/abstract_mysql_adapter.rb
@@ -41,7 +41,10 @@ module Instana
       end
 
       def execute_with_instana(sql, name = nil)
-        if !::Instana.tracer.tracing? || ignore_payload?(name, sql)
+        tracing = ::Instana.tracer.tracing?
+        if !tracing || ignore_payload?(name, sql)
+          return execute_without_instana(sql, name)
+        elsif ::Instana.tracer.current_span[:n] == :activerecord
           return execute_without_instana(sql, name)
         end
 

--- a/lib/instana/frameworks/instrumentation/active_record.rb
+++ b/lib/instana/frameworks/instrumentation/active_record.rb
@@ -11,18 +11,17 @@ if defined?(::ActiveRecord) && ::Instana.config[:active_record][:enabled]
     ::Instana.logger.info "Instrumenting ActiveRecord (mysql)"
     ActiveRecord::ConnectionAdapters::MysqlAdapter.send(:include, ::Instana::Instrumentation::MysqlAdapter)
     ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter.send(:include, ::Instana::Instrumentation::AbstractMysqlAdapter)
+  end
 
   # Mysql2
-  elsif defined?(ActiveRecord::ConnectionAdapters::Mysql2Adapter)
+  if defined?(ActiveRecord::ConnectionAdapters::Mysql2Adapter)
     ::Instana.logger.info "Instrumenting ActiveRecord (mysql2)"
     ActiveRecord::ConnectionAdapters::Mysql2Adapter.send(:include, ::Instana::Instrumentation::Mysql2Adapter)
+  end
 
   # Postgres
-  elsif defined?(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter)
+  if defined?(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter)
     ::Instana.logger.info "Instrumenting ActiveRecord (postgresql)"
     ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.send(:include, ::Instana::Instrumentation::PostgreSQLAdapter)
-
-  else
-    ::Instana.logger.debug "Unsupported ActiveRecord adapter"
   end
 end


### PR DESCRIPTION
A less common scenario of using two ActiveRecord adapters is not currently supported because of how we instrument ActiveRecord.  This PR allows multiple AR adapters to be instrumented simultaneously.