### PR TITLE
Announce cleanup and better custom tracing defaults

### DIFF
--- a/lib/instana/agent/helpers.rb
+++ b/lib/instana/agent/helpers.rb
@@ -52,7 +52,7 @@ module AgentHelpers
       end
     end
 
-    @state == :announced
+    @state == :ready
   rescue => e
     Instana.logger.debug { "#{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}" }
     Instana.logger.debug { e.backtrace.join("\r\n") } unless ENV.key?('INSTANA_TEST')

--- a/lib/instana/instrumentation/grpc.rb
+++ b/lib/instana/instrumentation/grpc.rb
@@ -39,7 +39,7 @@ if defined?(GRPC::ActiveCall) && ::Instana.config[:grpc][:enabled]
       alias #{call_type} #{call_type}_with_instana
     RUBY
   end
-  ::Instana.logger.info 'Instrumenting GRPC client'
+  ::Instana.logger.debug 'Instrumenting GRPC client'
 end
 
 if defined?(GRPC::RpcDesc) && ::Instana.config[:grpc][:enabled]
@@ -80,5 +80,5 @@ if defined?(GRPC::RpcDesc) && ::Instana.config[:grpc][:enabled]
       alias handle_#{call_type} handle_#{call_type}_with_instana
     RUBY
   end
-  ::Instana.logger.info 'Instrumenting GRPC server'
+  ::Instana.logger.debug 'Instrumenting GRPC server'
 end

--- a/lib/instana/instrumentation/resque.rb
+++ b/lib/instana/instrumentation/resque.rb
@@ -108,12 +108,12 @@ end
 if defined?(::Resque) && RUBY_VERSION >= '1.9.3'
 
   if ::Instana.config[:'resque-client'][:enabled]
-    ::Instana.logger.info 'Instrumenting Resque Client'
+    ::Instana.logger.debug 'Instrumenting Resque Client'
     ::Instana::Util.send_include(::Resque,         ::Instana::Instrumentation::ResqueClient)
   end
 
   if ::Instana.config[:'resque-worker'][:enabled]
-    ::Instana.logger.info 'Instrumenting Resque Worker'
+    ::Instana.logger.debug 'Instrumenting Resque Worker'
 
     ::Instana::Util.send_include(::Resque::Worker, ::Instana::Instrumentation::ResqueWorker)
     ::Instana::Util.send_include(::Resque::Job,    ::Instana::Instrumentation::ResqueJob)

--- a/test/instrumentation/dalli_test.rb
+++ b/test/instrumentation/dalli_test.rb
@@ -30,7 +30,7 @@ class DalliTest < Minitest::Test
     first_span = spans[1]
     second_span = spans[0]
 
-    validate_sdk_span(first_span, {:name => :dalli_test, :type => :intermediate})
+    validate_sdk_span(first_span, {:name => :dalli_test, :type => :entry})
 
     assert_equal :memcache, second_span[:n]
     assert_equal false, second_span.key?(:error)
@@ -63,7 +63,7 @@ class DalliTest < Minitest::Test
     first_span = spans[1]
     second_span = spans[0]
 
-    validate_sdk_span(first_span, {:name => :dalli_test, :type => :intermediate})
+    validate_sdk_span(first_span, {:name => :dalli_test, :type => :entry})
 
     assert_equal :memcache, second_span[:n]
     assert_equal false, second_span.key?(:error)
@@ -97,7 +97,7 @@ class DalliTest < Minitest::Test
     first_span = spans[1]
     second_span = spans[0]
 
-    validate_sdk_span(first_span, {:name => :dalli_test, :type => :intermediate})
+    validate_sdk_span(first_span, {:name => :dalli_test, :type => :entry})
 
     assert_equal :memcache, second_span[:n]
     assert_equal false, second_span.key?(:error)
@@ -131,7 +131,7 @@ class DalliTest < Minitest::Test
     first_span = spans[1]
     second_span = spans[0]
 
-    validate_sdk_span(first_span, {:name => :dalli_test, :type => :intermediate})
+    validate_sdk_span(first_span, {:name => :dalli_test, :type => :entry})
 
     assert_equal :memcache, second_span[:n]
     assert_equal false, second_span.key?(:error)
@@ -165,7 +165,7 @@ class DalliTest < Minitest::Test
     first_span = spans[1]
     second_span = spans[0]
 
-    validate_sdk_span(first_span, {:name => :dalli_test, :type => :intermediate})
+    validate_sdk_span(first_span, {:name => :dalli_test, :type => :entry})
 
     assert_equal :memcache, second_span[:n]
     assert_equal false, second_span.key?(:error)
@@ -199,7 +199,7 @@ class DalliTest < Minitest::Test
     first_span = spans[1]
     second_span = spans[0]
 
-    validate_sdk_span(first_span, {:name => :dalli_test, :type => :intermediate})
+    validate_sdk_span(first_span, {:name => :dalli_test, :type => :entry})
 
     assert_equal :memcache, second_span[:n]
     assert_equal false, second_span.key?(:error)
@@ -232,7 +232,7 @@ class DalliTest < Minitest::Test
     first_span = spans[1]
     second_span = spans[0]
 
-    validate_sdk_span(first_span, {:name => :dalli_test, :type => :intermediate})
+    validate_sdk_span(first_span, {:name => :dalli_test, :type => :entry})
 
     assert_equal :memcache, second_span[:n]
     assert_equal false, second_span.key?(:error)

--- a/test/instrumentation/excon_test.rb
+++ b/test/instrumentation/excon_test.rb
@@ -29,7 +29,7 @@ class ExconTest < Minitest::Test
     excon_span = find_first_span_by_name(spans, :excon)
     rack_span = find_first_span_by_name(spans, :rack)
 
-    validate_sdk_span(sdk_span, {:name => :'excon-test', :type => :intermediate})
+    validate_sdk_span(sdk_span, {:name => :'excon-test', :type => :entry})
 
     # data keys/values
     refute_nil excon_span.key?(:data)
@@ -72,7 +72,7 @@ class ExconTest < Minitest::Test
     excon_span = find_first_span_by_name(spans, :excon)
     sdk_span = find_first_span_by_name(spans, :'excon-test')
 
-    validate_sdk_span(sdk_span, {:name => :'excon-test', :type => :intermediate})
+    validate_sdk_span(sdk_span, {:name => :'excon-test', :type => :entry})
 
     assert_equal sdk_span[:s], excon_span[:p]
     assert_equal excon_span[:s], rack_span[:p]
@@ -111,7 +111,7 @@ class ExconTest < Minitest::Test
     excon_spans = find_spans_by_name(spans, :excon)
     sdk_span = find_first_span_by_name(spans, :'excon-test')
 
-    validate_sdk_span(sdk_span, {:name => :'excon-test', :type => :intermediate})
+    validate_sdk_span(sdk_span, {:name => :'excon-test', :type => :entry})
 
     assert_equal 3, rack_spans.length
     assert_equal 3, excon_spans.length

--- a/test/instrumentation/rest-client_test.rb
+++ b/test/instrumentation/rest-client_test.rb
@@ -25,7 +25,7 @@ class RestClientTest < Minitest::Test
     rest_span = find_first_span_by_name(spans, :'rest-client')
     net_span = find_first_span_by_name(spans, :'net-http')
 
-    validate_sdk_span(sdk_span, {:name => :'restclient-test', :type => :intermediate})
+    validate_sdk_span(sdk_span, {:name => :'restclient-test', :type => :entry})
     validate_sdk_span(rest_span, {:name => :'rest-client', :type => :intermediate})
 
     # Span name validation

--- a/test/instrumentation/sidekiq-client_test.rb
+++ b/test/instrumentation/sidekiq-client_test.rb
@@ -72,7 +72,7 @@ class SidekiqClientTest < Minitest::Test
     second_span = spans[0]
 
     assert_equal first_span[:s], second_span[:p]
-    validate_sdk_span(first_span, {:name => :sidekiqtests, :type => :intermediate})
+    validate_sdk_span(first_span, {:name => :sidekiqtests, :type => :entry})
 
     assert_equal :'sidekiq-client', second_span[:n]
     assert_equal 'some_random_queue', second_span[:data][:'sidekiq-client'][:queue]
@@ -89,7 +89,7 @@ class SidekiqClientTest < Minitest::Test
     second_span = spans[0]
 
     assert_equal first_span[:s], second_span[:p]
-    validate_sdk_span(first_span, {:name => :sidekiqtests, :type => :intermediate})
+    validate_sdk_span(first_span, {:name => :sidekiqtests, :type => :entry})
 
     assert_equal :'sidekiq-client', second_span[:n]
     assert_equal true, second_span[:error]

--- a/test/tracing/custom_test.rb
+++ b/test/tracing/custom_test.rb
@@ -31,6 +31,10 @@ class CustomTracingTest < Minitest::Test
     assert_equal :custom_trace, first_span[:data][:sdk][:name]
     assert_equal 1, first_span[:data][:sdk][:custom][:tags][:one]
 
+    # Custom tracing root spans should default to entry type
+    assert_equal 1, first_span[:k]
+    assert_equal :entry, first_span[:data][:sdk][:type]
+
     assert first_span.key?(:f)
     assert first_span[:f].key?(:e)
     assert first_span[:f].key?(:h)


### PR DESCRIPTION
When starting a new trace via OpenTracing or the bundled SDK, the first span in new traces now default to entry span kind.

https://docs.instana.io/quick_start/custom_tracing/#always-start-new-traces-with-entry-spans