### PR TITLE
Timers dependency: Assure min version of 4.0.4

### DIFF
--- a/instana.gemspec
+++ b/instana.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency('sys-proctable', '>= 1.2.2')
   spec.add_runtime_dependency('get_process_mem', '>= 0.2.1')
-  spec.add_runtime_dependency('timers', '>= 4.0.0')
+  spec.add_runtime_dependency('timers', '>= 4.0.4')
   spec.add_runtime_dependency('oj', '>=3.0.11') unless RUBY_PLATFORM =~ /java/i
 
   # Indirect dependency


### PR DESCRIPTION
The timers gem had a bug in versions >4.0.0 <4.0.4 causing a NoMethodError on the `now_and_every` method

https://github.com/socketry/timers/issues/50

This PR updates the gemspec to assure at least version 4.0.4 of the timers gem is installed.