### PR TITLE
Tracing: Faster initial trace collection

### DIFF
--- a/lib/instana/agent.rb
+++ b/lib/instana/agent.rb
@@ -316,6 +316,8 @@ module Instana
         return false
       end
 
+      ::Instana.logger.debug "Reporting #{spans.length} spans"
+
       path = sprintf(TRACES_PATH, @process[:report_pid])
       uri = URI.parse("http://#{@discovered[:agent_host]}:#{@discovered[:agent_port]}/#{path}")
       req = Net::HTTP::Post.new(uri)

--- a/lib/instana/agent/helpers.rb
+++ b/lib/instana/agent/helpers.rb
@@ -52,7 +52,7 @@ module AgentHelpers
       end
     end
 
-    @state == :ready
+    @state == :ready || @state == :announced
   rescue => e
     Instana.logger.debug { "#{__method__}:#{File.basename(__FILE__)}:#{__LINE__}: #{e.message}" }
     Instana.logger.debug { e.backtrace.join("\r\n") } unless ENV.key?('INSTANA_TEST')


### PR DESCRIPTION
At process boot, we usually wait for `:ready` state of the announce cycle to beging tracing.  This can take a few seconds and for command line execution, this can cause for some initial traces to be missed.

This PR changes this requirement to allow tracing after we've successfully announced to the Instana host agent but are pending `:ready` state so that traces are allowed to be collected much earlier in the boot process.