### PR TITLE
Set a service name for the EC2 Metadata Service.

### DIFF
--- a/lib/instana/config.rb
+++ b/lib/instana/config.rb
@@ -48,7 +48,7 @@ module Instana
       @config[:dalli]              = { :enabled => true }
       @config[:excon]              = { :enabled => true }
       @config[:grpc]               = { :enabled => true }
-      @config[:nethttp]            = { :enabled => true }
+      @config[:nethttp]            = { :enabled => true, :name_ec2_instance_metadata => defined?(Aws), :ec2_instance_metadata_host => '169.254.170.2' }
       @config[:redis]              = { :enabled => true }
       @config[:'resque-client']    = { :enabled => true }
       @config[:'resque-worker']    = { :enabled => true }

--- a/lib/instana/instrumentation/net-http.rb
+++ b/lib/instana/instrumentation/net-http.rb
@@ -33,6 +33,13 @@ if defined?(::Net::HTTP) && ::Instana.config[:nethttp][:enabled]
         end
       end
 
+      if ::Instana.config[:nethttp][:name_ec2_instance_metadata]
+        if (request.uri || @address) == ::Instana.config[:nethttp][:ec2_instance_metadata_host]
+          kv_payload[:service] = {}
+          kv_payload[:service][:name] = 'ec2_instance_metadata'
+        end
+      end
+
       # The core call
       response = request_without_instana(*args, &block)
 


### PR DESCRIPTION
The EC2 Metadata Service is hosted at a bogon ip (169.254.170.2)
and is used by the Ruby AWS SDK to access instance credentails via STS. It has
started showing up as an `Unmonitored` HTTP Span in our traces around the time that
Build 162 was released.

Per the documentationa around service naming, I belive this change should resolve
the issue.

Documentation:
* https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
* https://docs.instana.io/products/application_service_management/#using-the-call-tag-servicename