### PR TITLE
Allow SQL sanitization to be disabled (default: on)

### DIFF
--- a/lib/instana/config.rb
+++ b/lib/instana/config.rb
@@ -42,6 +42,16 @@ module Instana
       # ::Instana.config[:collect_backtraces] = true
       @config[:collect_backtraces] = false
 
+      # By default, collected SQL will be sanitized to remove potentially sensitive bind params such as:
+      #   > SELECT  "blocks".* FROM "blocks"  WHERE "blocks"."name" = "Mr. Smith"
+      #
+      # ...would be sanitized to be:
+      #   > SELECT  "blocks".* FROM "blocks"  WHERE "blocks"."name" = ?
+      #
+      # This sanitization step can be disabled by setting the following value to false.
+      # ::Instana.config[:sanitize_sql] = false
+      @config[:sanitize_sql] = true
+
       @config[:action_controller]  = { :enabled => true }
       @config[:action_view]        = { :enabled => true }
       @config[:active_record]      = { :enabled => true }

--- a/lib/instana/frameworks/instrumentation/mysql2_adapter.rb
+++ b/lib/instana/frameworks/instrumentation/mysql2_adapter.rb
@@ -24,7 +24,13 @@ module Instana
       #
       def collect(sql)
         payload = { :activerecord => {} }
-        payload[:activerecord][:sql] = sql.gsub(@@sanitize_regexp, '?')
+
+        if ::Instana.config[:sanitize_sql]
+          payload[:activerecord][:sql] = sql.gsub(@@sanitize_regexp, '?')
+        else
+          payload[:activerecord][:sql] = sql
+        end
+
         payload[:activerecord][:adapter] = @config[:adapter]
         payload[:activerecord][:host] = @config[:host]
         payload[:activerecord][:db] = @config[:database]

--- a/lib/instana/frameworks/instrumentation/mysql_adapter.rb
+++ b/lib/instana/frameworks/instrumentation/mysql_adapter.rb
@@ -21,7 +21,13 @@ module Instana
       #
       def collect(sql)
         payload = { :activerecord => {} }
-        payload[:activerecord][:sql] = sql.gsub(@@sanitize_regexp, '?')
+
+        if ::Instana.config[:sanitize_sql]
+          payload[:activerecord][:sql] = sql.gsub(@@sanitize_regexp, '?')
+        else
+          payload[:activerecord][:sql] = sql
+        end
+
         payload[:activerecord][:adapter] = @config[:adapter]
         payload[:activerecord][:host] = @config[:host]
         payload[:activerecord][:db] = @config[:database]

--- a/lib/instana/frameworks/instrumentation/postgresql_adapter.rb
+++ b/lib/instana/frameworks/instrumentation/postgresql_adapter.rb
@@ -29,7 +29,13 @@ module Instana
       #
       def collect(sql)
         payload = { :activerecord => {} }
-        payload[:activerecord][:sql] = sql.gsub(@@sanitize_regexp, '?')
+
+        if ::Instana.config[:sanitize_sql]
+          payload[:activerecord][:sql] = sql.gsub(@@sanitize_regexp, '?')
+        else
+          payload[:activerecord][:sql] = sql
+        end
+
         payload[:activerecord][:adapter] = @config[:adapter]
         payload[:activerecord][:host] = @config[:host]
         payload[:activerecord][:db] = @config[:database]

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -143,3 +143,22 @@ def find_span_by_id(spans, id)
   end
   raise Exception.new("Span with id (#{id}) not found")
 end
+
+# Finds the first span in +spans+ for which +block+ returns true
+#
+#     ar_span = find_first_span_by_qualifier(ar_spans) do |span|
+#       span[:data][:activerecord][:sql] == sql
+#     end
+#
+# This helper will raise an exception if no span evaluates to true against he provided block.
+#
+# +spans+: +Array+ of spans to search
+# +block+: The Ruby block to evaluate against each span
+def find_first_span_by_qualifier(spans, &block)
+  spans.each do |span|
+    if block.call(span)
+      return span
+    end
+  end
+  raise Exception.new("Span with qualifier not found")
+end


### PR DESCRIPTION
By default, collected SQL will be sanitized to remove potentially sensitive bind params such as:
  `> SELECT  "blocks".* FROM "blocks"  WHERE "blocks"."name" = "Mr. Smith"`

...would be sanitized to be:
  `> SELECT  "blocks".* FROM "blocks"  WHERE "blocks"."name" = ?`

This sanitization step can be disabled by setting the following value to false in a initializer such as `config/initializers/instana.rb`:
```ruby
::Instana.config[:sanitize_sql] = false
```