### PR TITLE
Instana::Rack - Fix handling of a string status (convert to integer)

### DIFF
--- a/test/frameworks/rails/actioncontroller_test.rb
+++ b/test/frameworks/rails/actioncontroller_test.rb
@@ -78,6 +78,25 @@ class ActionControllerTest < Minitest::Test
     assert_equal "Exception", ac_span[:data][:log][:parameters]
   end
 
+  def test_api_controller_404
+    # Run only when ActionController::API is used/defined
+    skip unless defined?(::ActionController::API)
+
+    clear_all!
+
+    Net::HTTP.get(URI.parse('http://localhost:3205/api/thispathdoesnotexist'))
+
+    spans = ::Instana.processor.queued_spans
+    assert_equal 1, spans.length
+
+    rack_span = find_first_span_by_name(spans, :rack)
+
+    assert_equal false, rack_span.key?(:error)
+    assert_equal "/api/thispathdoesnotexist", rack_span[:data][:http][:url]
+    assert_equal 404, rack_span[:data][:http][:status]
+    assert_equal "GET", rack_span[:data][:http][:method]
+  end
+
   def test_404
     clear_all!
 

--- a/test/frameworks/rails/actioncontroller_test.rb
+++ b/test/frameworks/rails/actioncontroller_test.rb
@@ -97,6 +97,30 @@ class ActionControllerTest < Minitest::Test
     assert_equal "GET", rack_span[:data][:http][:method]
   end
 
+  def test_api_controller_raise_routing_error
+    # Run only when ActionController::API is used/defined
+    skip unless defined?(::ActionController::API)
+
+    clear_all!
+
+    Net::HTTP.get(URI.parse('http://localhost:3205/api/raise_route_error'))
+
+    spans = ::Instana.processor.queued_spans
+    assert_equal 2, spans.length
+
+    rack_span = find_first_span_by_name(spans, :rack)
+    ac_span = find_first_span_by_name(spans, :actioncontroller)
+
+    assert_equal false, rack_span.key?(:error)
+    assert_equal "/api/raise_route_error", rack_span[:data][:http][:url]
+    assert_equal 404, rack_span[:data][:http][:status]
+    assert_equal "GET", rack_span[:data][:http][:method]
+
+    assert_equal true, ac_span[:error]
+    assert ac_span.key?(:stack)
+    assert 1, ac_span[:ec]
+  end
+
   def test_404
     clear_all!
 
@@ -105,8 +129,28 @@ class ActionControllerTest < Minitest::Test
     spans = ::Instana.processor.queued_spans
     assert_equal 1, spans.length
 
-    first_span = spans[0]
+    rack_span = find_first_span_by_name(spans, :rack)
 
-    assert_equal :rack, first_span[:n]
+    assert_equal false, rack_span.key?(:error)
+    assert_equal 404, rack_span[:data][:http][:status]
+  end
+
+  def test_raise_routing_error
+    clear_all!
+
+    Net::HTTP.get(URI.parse('http://localhost:3205/test/raise_route_error'))
+
+    spans = ::Instana.processor.queued_spans
+    assert_equal 2, spans.length
+
+    rack_span = find_first_span_by_name(spans, :rack)
+    ac_span = find_first_span_by_name(spans, :actioncontroller)
+
+    assert_equal false, rack_span.key?(:error)
+    assert_equal 404, rack_span[:data][:http][:status]
+
+    assert_equal true, ac_span[:error]
+    assert ac_span.key?(:stack)
+    assert 1, ac_span[:ec]
   end
 end

--- a/test/servers/rails_3205.rb
+++ b/test/servers/rails_3205.rb
@@ -39,9 +39,11 @@ class RailsTestApp < Rails::Application
     get "/test/render_js"             => "test#render_js"
     get "/test/render_alternate_layout"        => "test#render_alternate_layout"
     get "/test/render_partial_that_errors"     => "test#render_partial_that_errors"
+    get "/test/raise_route_error"     => "test#raise_route_error"
 
     get "/api/world" => "socket#world"
     get "/api/error" => "socket#error"
+    get "/api/raise_route_error" => "socket#raise_route_error"
   end
 
   # Enable cache classes. Production style.
@@ -172,6 +174,10 @@ class TestController < ActionController::Base
   def error
     raise Exception.new("Warning: This is a simulated Error")
   end
+
+  def raise_route_error
+    raise ActionController::RoutingError.new('Simulated not found')
+  end
 end
 
 if ::Rails::VERSION::MAJOR > 4
@@ -182,6 +188,10 @@ if ::Rails::VERSION::MAJOR > 4
       else
         render :text => "Hello api world!"
       end
+    end
+
+    def raise_route_error
+      raise ActionController::RoutingError.new('Simulated not found')
     end
 
     def error


### PR DESCRIPTION
This fixes a case where a Rack span may have been marked as errored because previous middleware in the stack may have passed a string status (not integer).

This seems to be valid according to the [Rack Spec](https://www.rubydoc.info/github/rack/rack/file/SPEC#label-The+Status).

We also add a bunch of 404 style tests to validate the case where this issue was originally seen.