### PR TITLE
Support OpenTracing.start_active_span and OpenTracing.active_span

### DIFF
--- a/lib/instana/tracer.rb
+++ b/lib/instana/tracer.rb
@@ -263,6 +263,27 @@ module Instana
       new_span
     end
 
+    # Start a new span which is the child of the current span
+    #
+    # @param operation_name [String] The name of the operation represented by the span
+    # @param child_of [Span] A span to be used as the ChildOf reference
+    # @param start_time [Time] the start time of the span
+    # @param tags [Hash] Starting tags for the span
+    #
+    # @return [Span]
+    #
+    def start_active_span(operation_name, child_of: self.current_span, start_time: ::Instana::Util.now_in_ms, tags: nil)
+      self.current_span = start_span(operation_name, child_of: child_of, start_time: start_time, tags: tags)
+    end
+
+    # Returns the currently active span
+    #
+    # @return [Span]
+    #
+    def active_span
+      self.current_span
+    end
+
     # Inject a span into the given carrier
     #
     # @param span_context [SpanContext]

--- a/test/tracing/opentracing_test.rb
+++ b/test/tracing/opentracing_test.rb
@@ -332,4 +332,25 @@ class OpenTracerTest < Minitest::Test
     assert_equal({:my_bag=>1}, ac_span.context.baggage)
     assert_equal(nil, av_span.context.baggage)
   end
+
+  def test_start_active_span
+    clear_all!
+
+    span = OpenTracing.start_active_span(:rack)
+    assert_equal ::Instana::Tracer.current_span, span
+
+    sleep 0.1
+
+    span.finish
+
+    spans = ::Instana.processor.queued_spans
+    assert_equal 1, spans.length
+  end
+
+  def test_active_span
+    clear_all!
+
+    span = OpenTracing.start_active_span(:rack)
+    assert_equal OpenTracing.active_span, span
+  end
 end


### PR DESCRIPTION
This brings Instana::Tracer closer to the API defined by opentracing-ruby.