### PR TITLE
Cuba Path Template Support

### DIFF
--- a/lib/instana/frameworks/cuba.rb
+++ b/lib/instana/frameworks/cuba.rb
@@ -1,6 +1,39 @@
 require "instana/rack"
 
+module Instana
+  module CubaPathTemplateExtractor
+    REPLACE_TARGET = /:(?<term>[^\/]+)/i
+    
+    def self.prepended(base)
+      ::Instana.logger.debug "#{base} prepended #{self}"
+    end
+    
+    def on(*args, &blk) 
+      wrapper = lambda do |*caputres|
+        env['INSTANA_PATH_TEMPLATE_FRAGMENTS'] << args
+          .select { |a| a.is_a?(String) }
+          .join('/')
+      
+        blk.call(*captures)
+      end
+      
+      super(*args, &wrapper)
+    end
+    
+    def call!(env)
+      env['INSTANA_PATH_TEMPLATE_FRAGMENTS'] = []
+      response = super(env)
+      env['INSTANA_HTTP_PATH_TEMPLATE'] = env['INSTANA_PATH_TEMPLATE_FRAGMENTS']
+        .join('/')
+        .gsub(REPLACE_TARGET, '{\k<term>}')
+      response
+    end
+  end
+end
+
+
 if defined?(::Cuba)
   ::Instana.logger.debug "Instrumenting Cuba"
   Cuba.use ::Instana::Rack
+  Cuba.prepend ::Instana::CubaPathTemplateExtractor
 end

--- a/lib/instana/instrumentation/rack.rb
+++ b/lib/instana/instrumentation/rack.rb
@@ -76,6 +76,11 @@ module Instana
           ::Instana.tracer.log_error(nil)
         end
 
+        # If the framework instrumentation provides a path template,
+        # pass it into the span here.
+        # See: https://www.instana.com/docs/tracing/custom-best-practices/#path-templates-visual-grouping-of-http-endpoints
+        kvs[:http][:path_tpl] = env['INSTANA_HTTP_PATH_TEMPLATE'] if env['INSTANA_HTTP_PATH_TEMPLATE']
+
         # Save the IDs before the trace ends so we can place
         # them in the response headers in the ensure block
         trace_id = ::Instana.tracer.current_span.trace_id

--- a/test/apps/cuba.rb
+++ b/test/apps/cuba.rb
@@ -7,6 +7,10 @@ Cuba.define do
     on "hello" do
       res.write "Hello Instana!"
     end
+    
+    on "greet/:name" do |name|
+      res.write "Hello, #{name}"
+    end
 
     on root do
       res.redirect '/hello'

--- a/test/frameworks/cuba_test.rb
+++ b/test/frameworks/cuba_test.rb
@@ -1,4 +1,3 @@
-
 if defined?(::Cuba)
   require 'test_helper'
   require File.expand_path(File.dirname(__FILE__) + '/../apps/cuba')
@@ -39,6 +38,20 @@ if defined?(::Cuba)
 
       assert first_span[:data][:http].key?(:host)
       assert_equal "example.org", first_span[:data][:http][:host]
+    end
+
+    def test_path_template
+      clear_all!
+
+      r = get '/greet/instana'
+      assert last_response.ok?
+
+      spans = ::Instana.processor.queued_spans
+      assert_equal 1, spans.count
+
+      first_span = spans.first
+      assert_equal :rack, first_span[:n]
+      assert_equal '/greet/{name}', first_span[:data][:http][:path_tpl]
     end
   end
 end


### PR DESCRIPTION
These changes add [path template](https://www.instana.com/docs/tracing/custom-best-practices/#path-templates-visual-grouping-of-http-endpoints) support to Ruby applications written using the Cuba framework. 