### PR TITLE
Path template support for Sinatra

### DIFF
--- a/lib/instana/frameworks/sinatra.rb
+++ b/lib/instana/frameworks/sinatra.rb
@@ -3,7 +3,24 @@ require "instana/rack"
 # This instrumentation will insert Rack into Sinatra _and_ Padrino since
 # the latter is based on Sinatra
 
+module Instana
+  module SinatraPathTemplateExtractor
+    def self.extended(base)
+      ::Instana.logger.debug "#{base} extended #{self}"
+      base.store_path_template
+    end
+    
+    def store_path_template
+      after do
+        @env["INSTANA_HTTP_PATH_TEMPLATE"] = @env["sinatra.route"]
+          .sub("#{@request.request_method} ", '')
+      end
+    end
+  end
+end
+
 if defined?(::Sinatra)
   ::Instana.logger.debug "Instrumenting Sinatra"
   ::Sinatra::Base.use ::Instana::Rack
+  ::Sinatra::Base.register ::Instana::SinatraPathTemplateExtractor
 end

--- a/test/apps/sinatra.rb
+++ b/test/apps/sinatra.rb
@@ -2,4 +2,8 @@ class InstanaSinatraApp < ::Sinatra::Base
   get '/' do
     "Hello Sinatra!"
   end
+  
+  get '/greet/:name' do
+    "Hello, #{params[:name]}!"
+  end
 end

--- a/test/frameworks/sinatra_test.rb
+++ b/test/frameworks/sinatra_test.rb
@@ -48,5 +48,19 @@ if defined?(::Sinatra)
       assert rack_span[:data][:http].key?(:host)
       assert_equal "example.org", rack_span[:data][:http][:host]
     end
+    
+    def test_path_template
+      clear_all!
+
+      r = get '/greet/instana'
+      assert last_response.ok?
+
+      spans = ::Instana.processor.queued_spans
+      assert_equal 1, spans.count
+
+      first_span = spans.first
+      assert_equal :rack, first_span[:n]
+      assert_equal '/greet/:name', first_span[:data][:http][:path_tpl]
+    end
   end
 end


### PR DESCRIPTION
These changes add [path template](https://www.instana.com/docs/tracing/custom-best-practices/#path-templates-visual-grouping-of-http-endpoints) support to Ruby applications written using the Sinatra framework. 