### PR TITLE
Path template support for Roda

### DIFF
--- a/lib/instana/frameworks/roda.rb
+++ b/lib/instana/frameworks/roda.rb
@@ -1,6 +1,47 @@
 require "instana/rack"
 
+module Instana
+  module RodaPathTemplateExtractor
+    module RequestMethods
+      TERM = defined?(::Roda) ? ::Roda::RodaPlugins::Base::RequestMethods::TERM : Object
+      
+      def if_match(args, &blk)
+        path = @remaining_path
+        captures = @captures.clear
+  
+        if match_all(args)
+          (env['INSTANA_PATH_TEMPLATE_FRAGMENTS'] ||= []).concat(named_args(args, blk))
+          block_result(blk.(*captures))
+          env['INSTANA_HTTP_PATH_TEMPLATE'] = env['INSTANA_PATH_TEMPLATE_FRAGMENTS']
+            .join('/')
+            .prepend('/')
+          throw :halt, response.finish
+        else
+          @remaining_path = path
+          false
+        end
+      end
+      
+      def named_args(args, blk)  
+        parameters = blk.parameters      
+        args.map do |a| 
+          case a
+          when String
+            a
+          when TERM
+            nil
+          else
+            _, name = parameters.pop
+            "{#{name}}"
+          end
+        end.compact
+      end  
+    end
+  end
+end
+
 if defined?(::Roda)
   ::Instana.logger.debug "Instrumenting Roda"
   Roda.use ::Instana::Rack
+  Roda.plugin ::Instana::RodaPathTemplateExtractor
 end

--- a/test/apps/roda.rb
+++ b/test/apps/roda.rb
@@ -6,5 +6,8 @@ class InstanaRodaApp < Roda
     r.get "hello" do
       "Hello Roda + Instana"
     end
+    r.get "greet", String do |name|
+      "Hello, #{name}!"
+    end
   end
 end

--- a/test/frameworks/roda_test.rb
+++ b/test/frameworks/roda_test.rb
@@ -40,5 +40,19 @@ if defined?(::Roda)
       assert first_span[:data][:http].key?(:host)
       assert_equal "example.org", first_span[:data][:http][:host]
     end
+    
+    def test_path_template
+      clear_all!
+
+      r = get '/greet/instana'
+      assert last_response.ok?
+
+      spans = ::Instana.processor.queued_spans
+      assert_equal 1, spans.count
+
+      first_span = spans.first
+      assert_equal :rack, first_span[:n]
+      assert_equal '/greet/{name}', first_span[:data][:http][:path_tpl]
+    end
   end
 end


### PR DESCRIPTION
These changes add [path template](https://www.instana.com/docs/tracing/custom-best-practices/#path-templates-visual-grouping-of-http-endpoints) support to Ruby applications written using the Roda framework. 