### PR TITLE
Path template support for Rails

### DIFF
--- a/lib/instana/frameworks/instrumentation/action_controller.rb
+++ b/lib/instana/frameworks/instrumentation/action_controller.rb
@@ -64,6 +64,15 @@ module Instana
         end
         name
       end
+      
+      def matched_path_template
+        Rails.application.routes.router.recognize(request) do |route, _, _|
+          path = route.path
+          return path.spec.to_s
+        end
+        
+        nil
+      end
     end
 
     # Used in ActionPack versions 5 and beyond, this module provides
@@ -83,6 +92,7 @@ module Instana
         ::Instana.tracer.log_entry(:actioncontroller, kv_payload)
 
         super(*args)
+        request.env['INSTANA_HTTP_PATH_TEMPLATE'] = matched_path_template
       rescue Exception => e
         ::Instana.tracer.log_error(e) unless has_rails_handler?(e)
         raise
@@ -135,6 +145,7 @@ module Instana
         ::Instana.tracer.log_entry(:actioncontroller, kv_payload)
 
         process_action_without_instana(*args)
+        request.env['INSTANA_HTTP_PATH_TEMPLATE'] = matched_path_template
       rescue Exception => e
         ::Instana.tracer.log_error(e) unless has_rails_handler?(e)
         raise

--- a/test/frameworks/rails/actioncontroller_test.rb
+++ b/test/frameworks/rails/actioncontroller_test.rb
@@ -153,4 +153,16 @@ class ActionControllerTest < Minitest::Test
     assert ac_span.key?(:stack)
     assert 1, ac_span[:ec]
   end
+  
+  def test_path_template
+    clear_all!
+
+    Net::HTTP.get(URI.parse('http://localhost:3205/test/world'))
+    
+    spans = ::Instana.processor.queued_spans
+    rack_span = find_first_span_by_name(spans, :rack)
+
+    assert_equal false, rack_span.key?(:error)
+    assert_equal '/test/world(.:format)', rack_span[:data][:http][:path_tpl]
+  end
 end


### PR DESCRIPTION
These changes add [path template](https://www.instana.com/docs/tracing/custom-best-practices/#path-templates-visual-grouping-of-http-endpoints) support to Ruby applications written using Rails. 