### PR TITLE
Support GraphQL Instrumentation

### DIFF
--- a/gemfiles/libraries.gemfile
+++ b/gemfiles/libraries.gemfile
@@ -65,6 +65,8 @@ if RUBY_VERSION < '2.2'
   gem 'rack', '< 2.0'
 end
 
+gem 'graphql'
+
 # Include the Instana Ruby gem's base set of gems
 gemspec :path => File.expand_path(File.dirname(__FILE__) + '/../')
 

--- a/lib/instana/config.rb
+++ b/lib/instana/config.rb
@@ -48,6 +48,7 @@ module Instana
       @config[:dalli]              = { :enabled => true }
       @config[:excon]              = { :enabled => true }
       @config[:grpc]               = { :enabled => true }
+      @config[:graphql]            = { :enabled => true }
       @config[:nethttp]            = { :enabled => true }
       @config[:redis]              = { :enabled => true }
       @config[:'resque-client']    = { :enabled => true }

--- a/lib/instana/instrumentation/graphql.rb
+++ b/lib/instana/instrumentation/graphql.rb
@@ -1,0 +1,77 @@
+if defined?(GraphQL::Schema) && defined?(GraphQL::Tracing::PlatformTracing) && ::Instana.config[:graphql][:enabled]
+  module Instana
+    class GraphqlTracing < GraphQL::Tracing::PlatformTracing
+      self.platform_keys = {
+        'lex' => 'lex.graphql',
+        'parse' => 'parse.graphql',
+        'validate' => 'validate.graphql',
+        'analyze_query' => 'analyze.graphql',
+        'analyze_multiplex' => 'analyze.graphql',
+        'execute_multiplex' => 'execute.graphql',
+        'execute_query' => 'execute.graphql',
+        'execute_query_lazy' => 'execute.graphql',
+      }
+      
+      def platform_trace(platform_key, key, data) 
+        return yield unless key == 'execute_query'    
+        operation = data[:query].selected_operation
+            
+        arguments = []
+        fields = []
+        
+        operation.selections.each do |field|
+          arguments.concat(walk_fields(field, :arguments))
+          fields.concat(walk_fields(field, :selections))    
+        end
+            
+        payload = {
+          operationName: data[:query].operation_name || 'anonymous',
+          operationType: operation.operation_type,
+          arguments: grouped_fields(arguments),
+          fields: grouped_fields(fields),
+        }
+                
+        begin
+          ::Instana.tracer.log_entry(:'graphql.server')
+          yield
+        rescue Exception => e
+          ::Instana.tracer.log_error(e)
+          raise e
+        ensure
+          ::Instana.tracer.log_exit(:'graphql.server', {graphql: payload})
+        end
+      end
+    
+      def platform_field_key(type, field)
+        "#{type.graphql_name}.#{field.graphql_name}"
+      end
+      
+      def platform_authorized_key(type)
+        "#{type.graphql_name}.authorized.graphql"
+      end
+
+      def platform_resolve_type_key(type)
+        "#{type.graphql_name}.resolve_type.graphql"
+      end
+      
+      private
+      
+      def walk_fields(parent, method)
+        return [] unless parent.respond_to?(method)
+        
+        parent.send(method).map do |field|
+          [{object: parent.name, field: field.name}] + walk_fields(field, method)
+        end.flatten
+      end
+      
+      def grouped_fields(fields)
+        fields
+          .group_by { |p| p[:object] }
+          .map { |name, p| [name, p.map { |f| f[:field] }] }
+          .to_h
+      end
+    end
+  end
+  
+  ::GraphQL::Schema.use(::Instana::GraphqlTracing)
+end

--- a/lib/instana/tracing/span.rb
+++ b/lib/instana/tracing/span.rb
@@ -3,8 +3,8 @@ module Instana
     REGISTERED_SPANS = [ :actioncontroller, :actionview, :activerecord, :excon,
                          :memcache, :'net-http', :rack, :render, :'rpc-client',
                          :'rpc-server', :'sidekiq-client', :'sidekiq-worker',
-                         :redis, :'resque-client', :'resque-worker' ].freeze
-    ENTRY_SPANS = [ :rack, :'resque-worker', :'rpc-server', :'sidekiq-worker' ].freeze
+                         :redis, :'resque-client', :'resque-worker', :'graphql.server'  ].freeze
+    ENTRY_SPANS = [ :rack, :'resque-worker', :'rpc-server', :'sidekiq-worker', :'graphql.server' ].freeze
     EXIT_SPANS = [ :activerecord, :excon, :'net-http', :'resque-client',
                    :'rpc-client', :'sidekiq-client', :redis ].freeze
     HTTP_SPANS = [ :rack, :excon, :'net-http' ].freeze

--- a/test/instrumentation/graphql_test.rb
+++ b/test/instrumentation/graphql_test.rb
@@ -1,0 +1,116 @@
+require 'test_helper'
+
+class GraphqlTest < Minitest::Test
+  class TaskType < GraphQL::Schema::Object
+    field :id, ID, null: false
+    field :action, String, null: false
+  end
+  
+  class NewTaskType < GraphQL::Schema::Mutation
+    argument :action, String, required: true
+    field :task, TaskType, null: true
+    
+    def resolve(action:)
+      {
+        task: OpenStruct.new(id: '0', action: action)
+      }
+    end
+  end
+  
+  class QueryType < GraphQL::Schema::Object
+    field :tasks, TaskType.connection_type, null: false
+    
+    def tasks()
+      [
+        OpenStruct.new(id: '0', action: 'Sample')
+      ]
+    end
+  end
+  
+  class MutationType < GraphQL::Schema::Object
+    field :create_task, mutation: NewTaskType
+  end
+  
+  class Schema < GraphQL::Schema
+    query QueryType
+    mutation MutationType
+  end
+  
+  def test_it_works
+    assert defined?(GraphQL)
+  end
+  
+  def test_config_defaults    
+    assert ::Instana.config[:graphql].is_a?(Hash)
+    assert ::Instana.config[:graphql].key?(:enabled)
+    assert_equal true, ::Instana.config[:graphql][:enabled]
+  end
+  
+  def test_query
+    clear_all!
+    
+    query = "query Sample {
+      tasks(after: \"\", first: 10) {
+        nodes {
+          action
+        }
+      }
+    }"
+    
+    expected_data = {
+      :operationName => "Sample",
+      :operationType => "query",
+      :arguments => { "tasks" => ["after", "first"] },
+      :fields => { "tasks" => ["nodes"], "nodes" => ["action"] }
+    }
+    expected_results = {
+      "data" => {
+        "tasks" => { 
+          "nodes" => [{ "action" => "Sample" }]
+        }
+      }
+    }
+    
+    results = Instana.tracer.start_or_continue_trace('graphql-test') { Schema.execute(query) }
+    query_span, root_span = *Instana.processor.queued_spans
+    
+    assert_equal expected_results, results.to_h
+    assert_equal :sdk, root_span[:n]
+    assert_equal :'graphql.server', query_span[:n]
+    assert_equal expected_data, query_span[:data][:graphql]
+  end
+  
+  def test_mutation
+    clear_all!
+    
+    query = "mutation Sample {
+      createTask(action: \"Sample\") {
+        task {
+          action
+        }
+      }
+    }"
+    
+    expected_data = {
+      :operationName => "Sample",
+      :operationType => "mutation",
+      :arguments => { "createTask" => ["action"] },
+      :fields => { "createTask" => ["task"], "task" => ["action"] }
+    }
+    expected_results = {
+      "data" => {
+        "createTask" => { 
+          "task" => { "action" => "Sample" }
+        }
+      }
+    }
+    
+    results = Instana.tracer.start_or_continue_trace('graphql-test') { Schema.execute(query) }
+    query_span, root_span = *Instana.processor.queued_spans
+        
+    assert_equal expected_results, results.to_h
+    assert_equal :sdk, root_span[:n]
+    assert_equal :'graphql.server', query_span[:n]
+    assert_equal expected_data, query_span[:data][:graphql]
+  end
+end


### PR DESCRIPTION
These changes add support for [GraphQL Ruby](https://graphql-ruby.org/), generating all [expected and documented](https://www.instana.com/docs/ecosystem/graphql/) tags. 