### PR TITLE
Remove the usage of method aliasing in the instrumentation

### DIFF
--- a/lib/instana/frameworks/instrumentation/active_record.rb
+++ b/lib/instana/frameworks/instrumentation/active_record.rb
@@ -9,19 +9,19 @@ if defined?(::ActiveRecord) && ::Instana.config[:active_record][:enabled]
   # Mysql
   if defined?(ActiveRecord::ConnectionAdapters::MysqlAdapter)
     ::Instana.logger.debug "Instrumenting ActiveRecord (mysql)"
-    ActiveRecord::ConnectionAdapters::MysqlAdapter.send(:include, ::Instana::Instrumentation::MysqlAdapter)
-    ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter.send(:include, ::Instana::Instrumentation::AbstractMysqlAdapter)
+    ActiveRecord::ConnectionAdapters::MysqlAdapter.send(:prepend, ::Instana::Instrumentation::MysqlAdapter)
+    ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter.send(:prepend, ::Instana::Instrumentation::AbstractMysqlAdapter)
   end
 
   # Mysql2
   if defined?(ActiveRecord::ConnectionAdapters::Mysql2Adapter)
     ::Instana.logger.debug "Instrumenting ActiveRecord (mysql2)"
-    ActiveRecord::ConnectionAdapters::Mysql2Adapter.send(:include, ::Instana::Instrumentation::Mysql2Adapter)
+    ActiveRecord::ConnectionAdapters::Mysql2Adapter.send(:prepend, ::Instana::Instrumentation::Mysql2Adapter)
   end
 
   # Postgres
   if defined?(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter)
     ::Instana.logger.debug "Instrumenting ActiveRecord (postgresql)"
-    ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.send(:include, ::Instana::Instrumentation::PostgreSQLAdapter)
+    ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.send(:prepend, ::Instana::Instrumentation::PostgreSQLAdapter)
   end
 end

--- a/lib/instana/instrumentation/grpc.rb
+++ b/lib/instana/instrumentation/grpc.rb
@@ -1,84 +1,94 @@
 call_types = [:request_response, :client_streamer, :server_streamer, :bidi_streamer]
 
 if defined?(GRPC::ActiveCall) && ::Instana.config[:grpc][:enabled]
-  call_types.each do |call_type|
-    GRPC::ClientStub.class_eval <<-RUBY, __FILE__, __LINE__ + 1
-      def #{call_type}_with_instana(method, *others, **options)
-        kvs = { rpc: {} }
+  module Instana
+    module GRPCCientInstrumentation
+      CALL_TYPES = [:request_response, :client_streamer, :server_streamer, :bidi_streamer]
 
-        unless ::Instana.tracer.tracing?
-          return #{call_type}_without_instana(method, *others, **options)
+      CALL_TYPES.each do |call_type|
+        define_method(call_type) do |method, *others, **options|
+          begin
+            kvs = { rpc: {} }
+
+            unless ::Instana.tracer.tracing?
+              return super(method, *others, **options)
+            end
+
+            kvs[:rpc][:flavor] = :grpc
+            kvs[:rpc][:host] = @host
+            kvs[:rpc][:call] = method
+            kvs[:rpc][:call_type] = call_type
+
+            ::Instana.tracer.log_entry(:'rpc-client', kvs)
+
+            context = ::Instana.tracer.context
+            if context
+              options[:metadata] = (options[:metadata] || {}).merge(
+                'x-instana-t' => context.trace_id_header,
+                'x-instana-s' => context.span_id_header
+              )
+            end
+
+            super(method, *others, **options)
+          rescue => e
+            kvs[:rpc][:error] = true
+            ::Instana.tracer.log_info(kvs)
+            ::Instana.tracer.log_error(e)
+            raise
+          ensure
+            ::Instana.tracer.log_exit(:'rpc-client', {})
+          end
         end
-
-        kvs[:rpc][:flavor] = :grpc
-        kvs[:rpc][:host] = @host
-        kvs[:rpc][:call] = method
-        kvs[:rpc][:call_type] = :#{call_type}
-
-        ::Instana.tracer.log_entry(:'rpc-client', kvs)
-
-        context = ::Instana.tracer.context
-        if context
-          options[:metadata] = (options[:metadata] || {}).merge(
-            'x-instana-t' => context.trace_id_header,
-            'x-instana-s' => context.span_id_header
-          )
-        end
-
-        #{call_type}_without_instana(method, *others, **options)
-      rescue => e
-        kvs[:rpc][:error] = true
-        ::Instana.tracer.log_info(kvs)
-        ::Instana.tracer.log_error(e)
-        raise
-      ensure
-        ::Instana.tracer.log_exit(:'rpc-client', {})
       end
-
-      alias #{call_type}_without_instana #{call_type}
-      alias #{call_type} #{call_type}_with_instana
-    RUBY
+    end
   end
+
   ::Instana.logger.debug 'Instrumenting GRPC client'
+  ::GRPC::ClientStub.prepend(::Instana::GRPCCientInstrumentation)
 end
 
 if defined?(GRPC::RpcDesc) && ::Instana.config[:grpc][:enabled]
-  call_types.each do |call_type|
-    GRPC::RpcDesc.class_eval <<-RUBY, __FILE__, __LINE__ + 1
-      def handle_#{call_type}_with_instana(active_call, mth, *others)
-        kvs = { rpc: {} }
-        metadata = active_call.metadata
+  module Instana
+    module GRPCServerInstrumentation
+      CALL_TYPES = [:request_response, :client_streamer, :server_streamer, :bidi_streamer]
 
-        incoming_context = {}
-        if metadata.key?('x-instana-t')
-          incoming_context[:trace_id]  = ::Instana::Util.header_to_id(metadata['x-instana-t'])
-          incoming_context[:span_id]   = ::Instana::Util.header_to_id(metadata['x-instana-s']) if metadata.key?('x-instana-s')
-          incoming_context[:level]     = metadata['x-instana-l'] if metadata.key?('x-instana-l')
+      CALL_TYPES.each do |call_type|
+        define_method(:"handle_#{call_type}") do |active_call, mth, *others|
+          begin
+            kvs = { rpc: {} }
+            metadata = active_call.metadata
+
+            incoming_context = {}
+            if metadata.key?('x-instana-t')
+              incoming_context[:trace_id]  = ::Instana::Util.header_to_id(metadata['x-instana-t'])
+              incoming_context[:span_id]   = ::Instana::Util.header_to_id(metadata['x-instana-s']) if metadata.key?('x-instana-s')
+              incoming_context[:level]     = metadata['x-instana-l'] if metadata.key?('x-instana-l')
+            end
+
+            kvs[:rpc][:flavor] = :grpc
+            kvs[:rpc][:host] = Socket.gethostname
+            kvs[:rpc][:call] = "/#{mth.owner.service_name}/#{name}"
+            kvs[:rpc][:call_type] = call_type
+            kvs[:rpc][:peer] = { address: active_call.peer }
+
+            ::Instana.tracer.log_start_or_continue(
+              :'rpc-server', kvs, incoming_context
+            )
+
+            super(active_call, mth, *others)
+          rescue => e
+            kvs[:rpc][:error] = true
+            ::Instana.tracer.log_info(kvs)
+            ::Instana.tracer.log_error(e)
+            raise
+          ensure
+            ::Instana.tracer.log_end(:'rpc-server', {}) if ::Instana.tracer.tracing?
+          end
         end
-
-        kvs[:rpc][:flavor] = :grpc
-        kvs[:rpc][:host] = Socket.gethostname
-        kvs[:rpc][:call] = "/\#{mth.owner.service_name}/\#{name}"
-        kvs[:rpc][:call_type] = :#{call_type}
-        kvs[:rpc][:peer] = { address: active_call.peer }
-
-        ::Instana.tracer.log_start_or_continue(
-          :'rpc-server', kvs, incoming_context
-        )
-
-        handle_#{call_type}_without_instana(active_call, mth, *others)
-      rescue => e
-        kvs[:rpc][:error] = true
-        ::Instana.tracer.log_info(kvs)
-        ::Instana.tracer.log_error(e)
-        raise
-      ensure
-        ::Instana.tracer.log_end(:'rpc-server', {}) if ::Instana.tracer.tracing?
       end
-
-      alias handle_#{call_type}_without_instana handle_#{call_type}
-      alias handle_#{call_type} handle_#{call_type}_with_instana
-    RUBY
+    end
   end
+
   ::Instana.logger.debug 'Instrumenting GRPC server'
+  ::GRPC::RpcDesc.prepend(::Instana::GRPCServerInstrumentation)
 end

--- a/lib/instana/instrumentation/rest-client.rb
+++ b/lib/instana/instrumentation/rest-client.rb
@@ -1,34 +1,24 @@
 module Instana
   module Instrumentation
     module RestClientRequest
-      def self.included(klass)
-        if klass.method_defined?(:execute)
-          klass.class_eval do
-            alias execute_without_instana execute
-            alias execute execute_with_instana
-          end
-        end
-      end
-
-      def execute_with_instana & block
+      def execute(&block)
         # Since RestClient uses net/http under the covers, we just
         # provide span visibility here.  HTTP related KVs are reported
         # in the Net::HTTP instrumentation
         ::Instana.tracer.log_entry(:'rest-client')
 
-        execute_without_instana(&block)
+        super(&block)
       rescue => e
         ::Instana.tracer.log_error(e)
         raise
       ensure
         ::Instana.tracer.log_exit(:'rest-client')
       end
-
     end
   end
 end
 
 if defined?(::RestClient::Request) && ::Instana.config[:'rest-client'][:enabled]
   ::Instana.logger.debug "Instrumenting RestClient"
-  ::RestClient::Request.send(:include, ::Instana::Instrumentation::RestClientRequest)
+  ::RestClient::Request.send(:prepend, ::Instana::Instrumentation::RestClientRequest)
 end

--- a/lib/instana/util.rb
+++ b/lib/instana/util.rb
@@ -2,46 +2,6 @@ module Instana
   module Util
     class << self
       ID_RANGE = -2**63..2**63-1
-
-      # An agnostic approach to method aliasing.
-      #
-      # @param klass [Object] The class or module that holds the method to be alias'd.
-      # @param method [Symbol] The name of the method to be aliased.
-      #
-      def method_alias(klass, method)
-        if klass.method_defined?(method.to_sym) ||
-            klass.private_method_defined?(method.to_sym)
-
-          with = "#{method}_with_instana"
-          without = "#{method}_without_instana"
-
-          klass.class_eval do
-            alias_method without, method.to_s
-            alias_method method.to_s, with
-          end
-        else
-          ::Instana.logger.debug "No such method (#{method}) to alias on #{klass}"
-        end
-      end
-
-      # Calls on target_class to 'extend' cls
-      #
-      # @param target_cls [Object] the class/module to do the 'extending'
-      # @param cls [Object] the class/module to be 'extended'
-      #
-      def send_extend(target_cls, cls)
-        target_cls.send(:extend, cls) if defined?(target_cls)
-      end
-
-      # Calls on <target_cls> to include <cls> into itself.
-      #
-      # @param target_cls [Object] the class/module to do the 'including'
-      # @param cls [Object] the class/module to be 'included'
-      #
-      def send_include(target_cls, cls)
-        target_cls.send(:include, cls) if defined?(target_cls)
-      end
-
       # Debugging helper method
       #
       def pry!
@@ -246,7 +206,7 @@ module Instana
       #
       def id_to_header(id)
         return '' unless id.is_a?(String)
-        # Only send 64bit IDs downstream for now 
+        # Only send 64bit IDs downstream for now
         id.length == 32 ? id[16..-1] : id
       end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -68,17 +68,11 @@ def clear_all!
 end
 
 def disable_redis_instrumentation
-  ::Redis::Client.class_eval do
-    alias call call_without_instana
-    alias call_pipeline call_pipeline_without_instana
-  end
+  ::Instana.config[:redis][:enabled] = false
 end
 
 def enable_redis_instrumentation
-  ::Redis::Client.class_eval do
-    alias call call_with_instana
-    alias call_pipeline call_pipeline_with_instana
-  end
+  ::Instana.config[:redis][:enabled] = true
 end
 
 def validate_sdk_span(json_span, sdk_hash = {}, errored = false, ec = 1)


### PR DESCRIPTION
This remove the usage of method aliasing from our instrumentation. For context, see [this](https://www.justinweiss.com/articles/rails-5-module-number-prepend-and-the-end-of-alias-method-chain/).