### PR TITLE
Support ActionCable

### DIFF
--- a/lib/instana/activators/action_cable.rb
+++ b/lib/instana/activators/action_cable.rb
@@ -1,0 +1,24 @@
+# (c) Copyright IBM Corp. 2021
+# (c) Copyright Instana Inc. 2021
+
+module Instana
+  module Activators
+    class ActionCable < Activator
+      def can_instrument?
+        defined?(::ActionCable::Connection::Base) && defined?(::ActionCable::Channel::Base)
+      end
+
+      def instrument
+        require 'instana/instrumentation/action_cable'
+
+        ::ActionCable::Connection::Base
+          .prepend(Instana::Instrumentation::ActionCableConnection)
+
+        ::ActionCable::Channel::Base
+          .prepend(Instana::Instrumentation::ActionCableChannel)
+
+        true
+      end
+    end
+  end
+end

--- a/lib/instana/instrumentation/action_cable.rb
+++ b/lib/instana/instrumentation/action_cable.rb
@@ -1,0 +1,47 @@
+# (c) Copyright IBM Corp. 2021
+# (c) Copyright Instana Inc. 2021
+
+module Instana
+  module Instrumentation
+    module ActionCableConnection
+      def instana_trace_context
+        @instana_trace_context
+      end
+
+      def process
+        @instana_trace_context ||= ::Instana.tracer.tracing? ? ::Instana.tracer.current_span.context : {}
+        super
+      end
+    end
+
+    module ActionCableChannel
+      def transmit(*args)
+        rpc_tags = {
+          flavor: :actioncable,
+          call: self.class.to_s,
+          call_type: :transmit,
+          host: Socket.gethostname
+        }
+
+        context = connection.instana_trace_context
+        ::Instana.tracer.start_or_continue_trace(:'rpc-server', {rpc: rpc_tags}, context) do
+          super(*args)
+        end
+      end
+
+      def dispatch_action(action, data)
+        rpc_tags = {
+          flavor: :actioncable,
+          call: "#{self.class}##{action}",
+          call_type: :action,
+          host: Socket.gethostname
+        }
+
+        context = connection.instana_trace_context
+        ::Instana.tracer.start_or_continue_trace(:'rpc-server', {rpc: rpc_tags}, context) do
+          super(action, data)
+        end
+      end
+    end
+  end
+end

--- a/test/instrumentation/rails_action_cable_test.rb
+++ b/test/instrumentation/rails_action_cable_test.rb
@@ -1,0 +1,131 @@
+# (c) Copyright IBM Corp. 2021
+# (c) Copyright Instana Inc. 2021
+
+require 'test_helper'
+
+require 'rails'
+require 'action_cable'
+
+require 'ostruct'
+require 'logger'
+
+class RailsActionCableTest < Minitest::Test
+  def setup
+    skip unless defined?(::ActionCable::Connection::Base)
+  end
+
+  def test_transmit_no_parent
+    clear_all!
+
+    connection = mock_connection
+    channel_klass = Class.new(ActionCable::Channel::Base)
+
+    channel_klass
+      .new(connection, :test)
+      .send(:transmit, 'action' => 'sample')
+
+    span, rest = Instana.processor.queued_spans
+    data = span[:data]
+
+    assert_nil rest
+    assert :"rpc-server", span[:n]
+    assert :actioncable, data[:rpc][:flavor]
+    assert channel_klass.to_s, data[:rpc][:call]
+    assert :transmit, data[:rpc][:call_type]
+    assert Socket.gethostname, data[:rpc][:host]
+  end
+
+  def test_transmit_parent
+    clear_all!
+
+    connection = mock_connection
+    connection.instance_variable_set(
+      :@instana_trace_context,
+      Instana::SpanContext.new('ABC', 'ABC')
+    )
+    channel_klass = Class.new(ActionCable::Channel::Base)
+
+    channel_klass
+      .new(connection, :test)
+      .send(:transmit, 'action' => 'sample')
+
+    span, rest = Instana.processor.queued_spans
+    data = span[:data]
+
+    assert_nil rest
+    assert 'ABC', span[:t]
+    assert :"rpc-server", span[:n]
+    assert :actioncable, data[:rpc][:flavor]
+    assert channel_klass.to_s, data[:rpc][:call]
+    assert :transmit, data[:rpc][:call_type]
+    assert Socket.gethostname, data[:rpc][:host]
+  end
+
+  def test_action_no_parent
+    clear_all!
+
+    connection = mock_connection
+    channel_klass = Class.new(ActionCable::Channel::Base) do
+      def sample
+        raise unless Instana.tracer.tracing?
+      end
+    end
+
+    channel_klass
+      .new(connection, :test)
+      .perform_action('action' => 'sample')
+
+    span, rest = Instana.processor.queued_spans
+    data = span[:data]
+
+    assert_nil rest
+    assert :"rpc-server", span[:n]
+    assert :actioncable, data[:rpc][:flavor]
+    assert "#{channel_klass}#sample", data[:rpc][:call]
+    assert :action, data[:rpc][:call_type]
+    assert Socket.gethostname, data[:rpc][:host]
+  end
+
+  def test_action_parent
+    clear_all!
+
+    connection = mock_connection
+    connection.instance_variable_set(
+      :@instana_trace_context,
+      Instana::SpanContext.new('ABC', 'ABC')
+    )
+    channel_klass = Class.new(ActionCable::Channel::Base) do
+      def sample
+        raise unless Instana.tracer.tracing?
+      end
+    end
+
+    channel_klass
+      .new(connection, :test)
+      .perform_action('action' => 'sample')
+
+    span, rest = Instana.processor.queued_spans
+    data = span[:data]
+
+    assert_nil rest
+    assert 'ABC', span[:t]
+    assert :"rpc-server", span[:n]
+    assert :actioncable, data[:rpc][:flavor]
+    assert "#{channel_klass}#sample", data[:rpc][:call]
+    assert :action, data[:rpc][:call_type]
+    assert Socket.gethostname, data[:rpc][:host]
+  end
+
+  private
+
+  def mock_connection
+    server = OpenStruct.new(
+      logger: Logger.new('/dev/null'),
+      worker_pool: nil,
+      config: OpenStruct.new(log_tags: [])
+    )
+    connection = ActionCable::Connection::Base.new(server, {})
+    connection.define_singleton_method(:transmit) { |*_args| true }
+    connection
+  end
+end

--- a/test/instrumentation/rails_active_record_test.rb
+++ b/test/instrumentation/rails_active_record_test.rb
@@ -4,8 +4,6 @@
 require 'test_helper'
 require 'support/apps/active_record/active_record'
 
-require 'irb'
-
 class RailsActiveRecordTest < Minitest::Test
   def setup
     skip unless ENV['DATABASE_URL']


### PR DESCRIPTION
This patch adds support for monitoring ActionCable. Each transmission sent to or action invoked on the cable will create a new RPC entry call linked to the web request that was hijacked to open the web socket.