### PR TITLE
Allow for INSTANA_ACTIVATE_SET to select the instrumentations to be loaded

### DIFF
--- a/lib/instana/activator.rb
+++ b/lib/instana/activator.rb
@@ -43,4 +43,14 @@ module Instana
   end
 end
 
-Dir["#{__dir__}/activators/*.rb"].sort.each { |f| require(f) }
+Dir["#{__dir__}/activators/*.rb"]
+  .sort
+  .select do |f|
+  if ENV['INSTANA_ACTIVATE_SET']
+    base = File.basename(f, '.rb')
+    ENV.fetch('INSTANA_ACTIVATE_SET', '').split(',').include?(base)
+  else
+    true
+  end
+end
+  .each { |f| require(f) }


### PR DESCRIPTION
If `INSTANA_ACTIVATE_SET` is present in the process environment, it will cause the library to only load the instrumentations listed. For example `env INSTANA_ACTIVATE_SET=rack,net_http bundle exec rails s` will only load the Rack and Net::HTTP instrumentations and skip all of the Rails ones. 

For all possible instrumentations see the list below:

<details>
<summary> Instrumentation List </summary>

```
action_cable
action_controller_api
action_controller_base
action_view
active_record
aws_sdk_dynamodb
aws_sdk_s3
aws_sdk_sns
aws_sdk_sqs
cuba
dalli
excon
graphql
grpc_client
grpc_server
net_http
rack
rails
redis
resque_client
resque_worker
rest_client
roda
shoryuken
sidekiq_client
sidekiq_worker
sinatra
```
</details>