### PR TITLE
Support Instana's Log collection

### DIFF
--- a/lib/instana/activator.rb
+++ b/lib/instana/activator.rb
@@ -7,7 +7,6 @@ module Instana
       attr_reader :trace_point, :activators
 
       def start
-        # :nocov:
         @trace_point = TracePoint.new(:end) do
           activated = ::Instana::Activator.call
           ::Instana.logger.debug { "Activated #{activated.join(', ')}" } unless activated.empty?
@@ -46,11 +45,13 @@ end
 Dir["#{__dir__}/activators/*.rb"]
   .sort
   .select do |f|
+  # :nocov:
   if ENV['INSTANA_ACTIVATE_SET']
     base = File.basename(f, '.rb')
     ENV.fetch('INSTANA_ACTIVATE_SET', '').split(',').include?(base)
   else
     true
   end
+  # :nocov:
 end
   .each { |f| require(f) }

--- a/lib/instana/config.rb
+++ b/lib/instana/config.rb
@@ -27,6 +27,9 @@ module Instana
       # Enable/disable tracing (default: enabled)
       @config[:tracing] = { :enabled => true }
 
+      # Enable/Disable logging
+      @config[:logging] = { :enabled => true }
+
       # Collector interval
       @config[:collector] = { :enabled => true, :interval => 1 }
 

--- a/lib/instana/frameworks/rails.rb
+++ b/lib/instana/frameworks/rails.rb
@@ -3,9 +3,6 @@
 
 if ::Rails::VERSION::MAJOR < 3
   ::Rails.configuration.after_initialize do
-    # In Rails, let's use the Rails logger
-    ::Instana.logger = ::Rails.logger if ::Rails.logger
-
     if ::Instana.config[:tracing][:enabled]
       ::Instana.logger.debug "Instrumenting Rack"
       ::Rails.configuration.middleware.insert 0, ::Instana::Rack
@@ -17,8 +14,11 @@ else
   module ::Instana
     class Railtie < ::Rails::Railtie
       initializer 'instana.rack' do |app|
-        # In Rails, let's use the Rails logger
-        ::Instana.logger = ::Rails.logger if ::Rails.logger
+        # Configure the Instrumented Logger
+        if ::Instana.config[:logging][:enabled] && !ENV.key?('INSTANA_TEST')
+          logger = ::Instana::InstrumentedLogger.new('/dev/null')
+          Rails.logger.extend(ActiveSupport::Logger.broadcast(logger))
+        end
 
         if ::Instana.config[:tracing][:enabled]
           ::Instana.logger.debug "Instrumenting Rack"

--- a/lib/instana/instrumented_logger.rb
+++ b/lib/instana/instrumented_logger.rb
@@ -1,0 +1,26 @@
+# (c) Copyright IBM Corp. 2021
+# (c) Copyright Instana Inc. 2021
+
+module Instana
+  class InstrumentedLogger < Logger
+    LEVEL_LABELS = %w[Debug Info Warn Error Fatal Any].freeze
+
+    def instana_log_level
+      WARN
+    end
+
+    def add(severity, message = nil, progname = nil)
+      severity ||= UNKNOWN
+
+      if severity >= instana_log_level && ::Instana.tracer.tracing?
+        tags = {
+          level: LEVEL_LABELS[severity],
+          message: "#{message} #{progname}".strip
+        }
+        Instana::Tracer.trace(:log, {log: tags}) {}
+      end
+
+      super(severity, message, progname)
+    end
+  end
+end

--- a/lib/instana/setup.rb
+++ b/lib/instana/setup.rb
@@ -1,10 +1,12 @@
 # (c) Copyright IBM Corp. 2021
 # (c) Copyright Instana Inc. 2016
 
+require 'logger'
 require 'concurrent'
 require 'sys-proctable'
 
 require 'instana/logger_delegator'
+require 'instana/instrumented_logger'
 
 require "instana/base"
 require "instana/config"

--- a/lib/instana/tracing/span.rb
+++ b/lib/instana/tracing/span.rb
@@ -6,10 +6,10 @@ module Instana
     REGISTERED_SPANS = [ :actioncontroller, :actionview, :activerecord, :excon,
                          :memcache, :'net-http', :rack, :render, :'rpc-client',
                          :'rpc-server', :'sidekiq-client', :'sidekiq-worker',
-                         :redis, :'resque-client', :'resque-worker', :'graphql.server', :dynamodb, :s3, :sns, :sqs, :'aws.lambda.entry', :activejob  ].freeze
+                         :redis, :'resque-client', :'resque-worker', :'graphql.server', :dynamodb, :s3, :sns, :sqs, :'aws.lambda.entry', :activejob, :log  ].freeze
     ENTRY_SPANS = [ :rack, :'resque-worker', :'rpc-server', :'sidekiq-worker', :'graphql.server', :sqs, :'aws.lambda.entry' ].freeze
     EXIT_SPANS = [ :activerecord, :excon, :'net-http', :'resque-client',
-                   :'rpc-client', :'sidekiq-client', :redis, :dynamodb, :s3, :sns, :sqs ].freeze
+                   :'rpc-client', :'sidekiq-client', :redis, :dynamodb, :s3, :sns, :sqs, :log ].freeze
     HTTP_SPANS = [ :rack, :excon, :'net-http' ].freeze
 
     attr_accessor :parent

--- a/test/tracing/instrumented_logger_test.rb
+++ b/test/tracing/instrumented_logger_test.rb
@@ -1,0 +1,36 @@
+# (c) Copyright IBM Corp. 2021
+# (c) Copyright Instana Inc. 2021
+
+require 'test_helper'
+
+class InstrumentedLoggerTest < Minitest::Test
+  def test_log_warn_error
+    subject = Instana::InstrumentedLogger.new('/dev/null')
+
+    Instana::Tracer.start_or_continue_trace(:test_logging) do
+      subject.warn('warn')
+      subject.debug('test')
+      subject.error('error')
+    end
+
+    spans = ::Instana.processor.queued_spans
+    pp spans
+
+    warn_span, error_span, = *spans
+
+    assert_equal :log, warn_span[:n]
+    assert_equal 'warn', warn_span[:data][:log][:message]
+    assert_equal 'Warn', warn_span[:data][:log][:level]
+
+    assert_equal :log, error_span[:n]
+    assert_equal 'error', error_span[:data][:log][:message]
+    assert_equal 'Error', error_span[:data][:log][:level]
+  end
+
+  def test_no_trace
+    subject = Instana::InstrumentedLogger.new('/dev/null')
+    subject.warn('warn')
+
+    assert_equal [], ::Instana.processor.queued_spans
+  end
+end


### PR DESCRIPTION
Includes a subclass of the standard logger which logs to Instana, and extends Rails' per-configured logger on versions 4 and above. 