### PR TITLE
Monitor ActionMailer

### DIFF
--- a/lib/instana/activators/action_mailer.rb
+++ b/lib/instana/activators/action_mailer.rb
@@ -1,0 +1,22 @@
+# (c) Copyright IBM Corp. 2021
+# (c) Copyright Instana Inc. 2021
+
+module Instana
+  module Activators
+    class ActionMailer < Activator
+      def can_instrument?
+        defined?(::ActionMailer::Base)
+      end
+
+      def instrument
+        require 'instana/instrumentation/action_mailer'
+
+        ::ActionMailer::Base
+          .singleton_class
+          .prepend(Instana::Instrumentation::ActionMailer)
+
+        true
+      end
+    end
+  end
+end

--- a/lib/instana/instrumentation/action_mailer.rb
+++ b/lib/instana/instrumentation/action_mailer.rb
@@ -1,0 +1,22 @@
+# (c) Copyright IBM Corp. 2021
+# (c) Copyright Instana Inc. 2021
+
+module Instana
+  module Instrumentation
+    module ActionMailer
+      def method_missing(method_name, *args) # rubocop:disable Style/MissingRespondToMissing
+        if action_methods.include?(method_name.to_s)
+          tags = {
+            actionmailer: {
+              class: to_s,
+              method: method_name.to_s
+            }
+          }
+          Instana::Tracer.trace(:'mail.actionmailer', tags) { super }
+        else
+          super
+        end
+      end
+    end
+  end
+end

--- a/lib/instana/tracing/span.rb
+++ b/lib/instana/tracing/span.rb
@@ -6,10 +6,10 @@ module Instana
     REGISTERED_SPANS = [ :actioncontroller, :actionview, :activerecord, :excon,
                          :memcache, :'net-http', :rack, :render, :'rpc-client',
                          :'rpc-server', :'sidekiq-client', :'sidekiq-worker',
-                         :redis, :'resque-client', :'resque-worker', :'graphql.server', :dynamodb, :s3, :sns, :sqs, :'aws.lambda.entry', :activejob, :log  ].freeze
+                         :redis, :'resque-client', :'resque-worker', :'graphql.server', :dynamodb, :s3, :sns, :sqs, :'aws.lambda.entry', :activejob, :log, :"mail.actionmailer"  ].freeze
     ENTRY_SPANS = [ :rack, :'resque-worker', :'rpc-server', :'sidekiq-worker', :'graphql.server', :sqs, :'aws.lambda.entry' ].freeze
     EXIT_SPANS = [ :activerecord, :excon, :'net-http', :'resque-client',
-                   :'rpc-client', :'sidekiq-client', :redis, :dynamodb, :s3, :sns, :sqs, :log ].freeze
+                   :'rpc-client', :'sidekiq-client', :redis, :dynamodb, :s3, :sns, :sqs, :log, :"mail.actionmailer" ].freeze
     HTTP_SPANS = [ :rack, :excon, :'net-http' ].freeze
 
     attr_accessor :parent

--- a/test/instrumentation/rails_action_mailer_test.rb
+++ b/test/instrumentation/rails_action_mailer_test.rb
@@ -1,0 +1,37 @@
+# (c) Copyright IBM Corp. 2021
+# (c) Copyright Instana Inc. 2021
+
+require 'test_helper'
+require 'action_mailer'
+
+class RailsActionMailerTest < Minitest::Test
+  class TestMailer < ActionMailer::Base
+    def sample_email
+      mail(
+        from: 'test@example.com',
+        to: 'test@example.com',
+        subject: 'Test Email',
+        body: 'Hello',
+        content_type: "text/html"
+      )
+    end
+  end
+
+  def setup
+    TestMailer.delivery_method = :sendmail
+
+    clear_all!
+  end
+
+  def test_mailer
+    Instana.tracer.start_or_continue_trace(:test) do
+      TestMailer.sample_email.deliver_now
+    end
+
+    mail_span, = *::Instana.processor.queued_spans
+
+    assert_equal :"mail.actionmailer", mail_span[:n]
+    assert_equal 'RailsActionMailerTest::TestMailer', mail_span[:data][:actionmailer][:class]
+    assert_equal 'sample_email', mail_span[:data][:actionmailer][:method]
+  end
+end


### PR DESCRIPTION
Generate a new intermediate call when ActionMailer is invoked from within a tracing context. 