### PR TITLE
Fix exception when remove_from_query is called with nil

### DIFF
--- a/lib/instana/instrumentation/net-http.rb
+++ b/lib/instana/instrumentation/net-http.rb
@@ -36,7 +36,7 @@ module Instana
         if request.uri
           uri_without_query = request.uri.dup.tap { |r| r.query = nil }
           kv_payload[:http][:url] = uri_without_query.to_s.gsub(/\?\z/, '')
-          kv_payload[:http][:params] = ::Instana.secrets.remove_from_query(request.uri.query)
+          kv_payload[:http][:params] = ::Instana.secrets.remove_from_query(request.uri.query) if !request.uri.query.nil?
         else
           if use_ssl?
             kv_payload[:http][:url] = "https://#{@address}:#{@port}#{request.path}"

--- a/lib/instana/instrumentation/net-http.rb
+++ b/lib/instana/instrumentation/net-http.rb
@@ -36,7 +36,7 @@ module Instana
         if request.uri
           uri_without_query = request.uri.dup.tap { |r| r.query = nil }
           kv_payload[:http][:url] = uri_without_query.to_s.gsub(/\?\z/, '')
-          kv_payload[:http][:params] = ::Instana.secrets.remove_from_query(request.uri.query) if !request.uri.query.nil?
+          kv_payload[:http][:params] = ::Instana.secrets.remove_from_query(request.uri.query)
         else
           if use_ssl?
             kv_payload[:http][:url] = "https://#{@address}:#{@port}#{request.path}"

--- a/lib/instana/secrets.rb
+++ b/lib/instana/secrets.rb
@@ -11,7 +11,7 @@ module Instana
     end
 
     def remove_from_query(str, secret_values = Instana.agent.secret_values)
-      return str unless secret_values
+      return str unless secret_values && !str.nil?
 
       begin
         url = URI(str)

--- a/test/secrets_test.rb
+++ b/test/secrets_test.rb
@@ -88,6 +88,15 @@ class SecretsTest < Minitest::Test
     assert_redacted @subject.remove_from_query(url, sample_config), %w(filter[instantiate]), raw_str: true
   end
 
+  def test_with_nil
+    sample_config = {
+      "matcher"=>"contains",
+      "list"=>["stan"]
+    }
+
+    assert_equal @subject.remove_from_query(nil, sample_config), nil
+  end
+
   private
 
   def url_for(keys)


### PR DESCRIPTION
~Only capture uri.query if it's not nil~
Fix exception when remove_from_query is called with nil
fixes #250