### PR TITLE
Include a config option to disable Resque propagation

### DIFF
--- a/lib/instana/config.rb
+++ b/lib/instana/config.rb
@@ -67,7 +67,7 @@ module Instana
       @config[:graphql]            = { :enabled => true }
       @config[:nethttp]            = { :enabled => true }
       @config[:redis]              = { :enabled => true }
-      @config[:'resque-client']    = { :enabled => true }
+      @config[:'resque-client']    = { :enabled => true, :propagate => true }
       @config[:'resque-worker']    = { :enabled => true, :'setup-fork' => true }
       @config[:'rest-client']      = { :enabled => true }
       @config[:'sidekiq-client']   = { :enabled => true }

--- a/test/support/apps/resque/jobs/resque_fast_job.rb
+++ b/test/support/apps/resque/jobs/resque_fast_job.rb
@@ -7,7 +7,9 @@ require "net/http"
 class FastJob
   @queue = :critical
 
-  def self.perform
+  def self.perform(*args)
+    raise 'Invalid Args' unless args.empty?
+
     if ENV.key?('REDIS_URL')
       redis = Redis.new(:url => ENV['REDIS_URL'])
     elsif ENV.key?('REDIS_URL')


### PR DESCRIPTION
In cases where the enqueue/dequeue behavior is being overridden setting `::Instana.config[:'resque-client'][:propagate] = false` allows a way to fall back to the "old" instrumentation and skip trace propagation. 