### PR TITLE
Add SonarQube analysis parameter for PR analysis

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,15 +143,24 @@ commands:
           command: |
             wget -O /tmp/sonar-scanner-cli.zip https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-4.6.2.2472.zip
             unzip -d /tmp /tmp/sonar-scanner-cli.zip
-            /tmp/sonar-scanner-4.6.2.2472/bin/sonar-scanner \
-            -Dsonar.projectKey=ruby-sensor \
-            -Dsonar.sources=. \
-            -Dsonar.host.url="${SONARQUBE_URL}" \
-            -Dsonar.login="${SONARQUBE_LOGIN}" \
-            -Dsonar.branch.name="${CIRCLE_BRANCH}" \
-            -Dsonar.pullrequest.key="${CIRCLE_PR_NUMBER}" \
-            -Dsonar.pullrequest.branch="${CIRCLE_BRANCH}" \
-            -Dsonar.ruby.coverage.reportPaths=./coverage/coverage.json
+            if [[ -n "${CIRCLE_PR_NUMBER}" ]]; then
+              /tmp/sonar-scanner-4.6.2.2472/bin/sonar-scanner \
+                -Dsonar.projectKey=ruby-sensor \
+                -Dsonar.sources=. \
+                -Dsonar.host.url="${SONARQUBE_URL}" \
+                -Dsonar.login="${SONARQUBE_LOGIN}" \
+                -Dsonar.pullrequest.key="${CIRCLE_PR_NUMBER}" \
+                -Dsonar.pullrequest.branch="${CIRCLE_BRANCH}" \
+                -Dsonar.ruby.coverage.reportPaths=./coverage/coverage.json
+            else
+              /tmp/sonar-scanner-4.6.2.2472/bin/sonar-scanner \
+                -Dsonar.projectKey=ruby-sensor \
+                -Dsonar.sources=. \
+                -Dsonar.host.url="${SONARQUBE_URL}" \
+                -Dsonar.login="${SONARQUBE_LOGIN}" \
+                -Dsonar.branch.name="${CIRCLE_BRANCH}" \
+                -Dsonar.ruby.coverage.reportPaths=./coverage/coverage.json
+            fi
   run_tests:
     steps:
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,6 +149,8 @@ commands:
             -Dsonar.host.url="${SONARQUBE_URL}" \
             -Dsonar.login="${SONARQUBE_LOGIN}" \
             -Dsonar.branch.name="${CIRCLE_BRANCH}" \
+            -Dsonar.pullrequest.key="${CIRCLE_PR_NUMBER}" \
+            -Dsonar.pullrequest.branch="${CIRCLE_BRANCH}" \
             -Dsonar.ruby.coverage.reportPaths=./coverage/coverage.json
   run_tests:
     steps:


### PR DESCRIPTION
`sonar.pullrequest.base` is missing because CircleCI doesn't expose the base branch in an environment variable.

https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables
https://docs.sonarqube.org/9.0/analysis/pull-request/#header-4