### PR TITLE
Add backtrace_path_filter config option

### DIFF
--- a/lib/instana/tracing/span.rb
+++ b/lib/instana/tracing/span.rb
@@ -82,8 +82,8 @@ module Instana
     # @param limit [Integer] Limit the backtrace to the top <limit> frames
     #
     def add_stack(limit: 30, stack: Kernel.caller)
-      filter = ::Instana.config[:backtrace_path_filter]
-      stack = stack.select { |line| line.include?(filter) } if filter
+      cleaner = ::Instana.config[:backtrace_cleaner]
+      stack = cleaner.call(stack) if cleaner
 
       @data[:stack] = stack
                       .map do |call|

--- a/lib/instana/tracing/span.rb
+++ b/lib/instana/tracing/span.rb
@@ -82,6 +82,9 @@ module Instana
     # @param limit [Integer] Limit the backtrace to the top <limit> frames
     #
     def add_stack(limit: 30, stack: Kernel.caller)
+      filter = ::Instana.config[:backtrace_path_filter]
+      stack = stack.select { |line| line.include?(filter) } if filter
+
       @data[:stack] = stack
                       .map do |call|
         file, line, *method = call.split(':')

--- a/test/tracing/span_test.rb
+++ b/test/tracing/span_test.rb
@@ -63,6 +63,18 @@ class SpanTest < Minitest::Test
     Instana.config[:collect_backtraces] = false
   end
 
+  def test_span_backtrace_cleaner
+    Instana.config[:collect_backtraces] = true
+    Instana.config[:backtrace_cleaner] =
+      ->(trace) { trace.filter { |line| line.include?("lib/instana") } }
+    span = Instana::Span.new(:excon)
+
+    assert_equal 1, span[:stack].size
+  ensure
+    Instana.config[:backtrace_cleaner] = nil
+    Instana.config[:collect_backtraces] = false
+  end
+
   def test_span_stack_over_limit
     def inner(depth = 50, &blk) # rubocop:disable Lint/NestedMethodDefinition
       return blk.call if depth.zero?


### PR DESCRIPTION
## What

Adds a config option called `backtrace_path_filter` that allows the lines in backtraces to be compared against the filter to see if they should be included in the backtrace

## Why

Backtraces are limited to a number of lines (default 30) and are often coming from so deep in library/framework code that you may not even see the originating user code in the backtrace. However, library code is often located in a different path than user code. This can be leveraged to filter the call stack to relevant code.

```ruby
[
  '/usr/local/bundle/rails/...',
  '/usr/local/bundle/rails/...',
  '/usr/local/bundle/rails/...',
  '/usr/local/bundle/rails/...',
  '/usr/local/bundle/rails/...',
  '/usr/local/bundle/rails/...',
  '/usr/local/bundle/rails/...',
  '/usr/local/bundle/rails/...',
  '/usr/local/bundle/rails/...',
  # potentially many more lines...
  '/var/www/app/my/model.rb',
  '/var/www/app/my/controller.rb',
  '/usr/local/bundle/rails/...',
  '/usr/local/bundle/rails/...'
]

# With `backtrace_path_filter` set to `/var/www/app/` becomes:

[
  '/var/www/app/my/model.rb',
  '/var/www/app/my/controller.rb'
]
```