### PR TITLE
Read extra http headers config from tracing object of discovery response

### DIFF
--- a/lib/instana/backend/host_agent.rb
+++ b/lib/instana/backend/host_agent.rb
@@ -52,9 +52,15 @@ module Instana
         }.reject { |_, v| v.nil? }
       end
 
-      # @return [Array] extra headers to include in the trace
+      # @return [Array] extra headers to capture with HTTP spans
       def extra_headers
-        discovery_value['extraHeaders']
+        if discovery_value['tracing']
+          # Starting with discovery version 1.6.4, this value is in tracing.extra-http-headers.
+          discovery_value['tracing']['extra-http-headers']
+        else
+          # Legacy fallback for discovery versions <= 1.6.3.
+          discovery_value['extraHeaders']
+        end
       end
 
       # @return [Hash] values which are removed from urls sent to the backend

--- a/test/backend/host_agent_test.rb
+++ b/test/backend/host_agent_test.rb
@@ -45,6 +45,24 @@ class HostAgentTest < Minitest::Test
     assert_equal 1, subject.source[:e]
   end
 
+  def test_extra_headers_from_tracing_config
+    discovery = Concurrent::Atom.new(
+      {
+        'tracing' => {
+          'extra-http-headers' => ["X-Header-1", "X-Header-2"]
+        }
+      }
+    )
+    subject = Instana::Backend::HostAgent.new(discovery: discovery)
+    assert_equal ["X-Header-1", "X-Header-2"], subject.extra_headers
+  end
+
+  def test_extra_headers_legacy
+    discovery = Concurrent::Atom.new({'extraHeaders' => ["X-Header-3", "X-Header-4"]})
+    subject = Instana::Backend::HostAgent.new(discovery: discovery)
+    assert_equal ["X-Header-3", "X-Header-4"], subject.extra_headers
+  end
+
   def test_start
     subject = Instana::Backend::HostAgent.new
     assert subject.respond_to? :start


### PR DESCRIPTION
Additional context:
* This is related to this sensor change: https://github.ibm.com/instana/sensors/pull/342 (released via https://github.ibm.com/instana/agent-update-site/pull/574 as discovery/sensor version 1.6.4). This has been rolled out in May already.
* The change in the agent-side sensor as well as in the in-process collector here are backwards compatible. I've tested that the old (< 1.6.4) discovery agent plug-in works with the updated in-process collector code and vice versa (new discovery plug-in 1.6.4 with old in-process collector code). Obviously I also tested the latest discovery version with the updated in-process collector code, that is, with this change.