### PR TITLE
Add Ruby 3.0 Support - Delegation Methods

### DIFF
--- a/lib/instana/backend/agent.rb
+++ b/lib/instana/backend/agent.rb
@@ -32,11 +32,11 @@ module Instana
         @delegate.setup
       end
 
-      def method_missing(mth, *args, &block)
+      def method_missing(mth, *args, **kwargs, &block)
         if @delegate.respond_to?(mth)
-          @delegate.public_send(mth, *args, &block)
+          @delegate.public_send(mth, *args, **kwargs, &block)
         else
-          super(mth, *args, &block)
+          super(mth, *args, **kwargs, &block)
         end
       end
 

--- a/lib/instana/backend/agent.rb
+++ b/lib/instana/backend/agent.rb
@@ -32,13 +32,14 @@ module Instana
         @delegate.setup
       end
 
-      def method_missing(mth, *args, **kwargs, &block)
+      def method_missing(mth, *args, &block)
         if @delegate.respond_to?(mth)
-          @delegate.public_send(mth, *args, **kwargs, &block)
+          @delegate.public_send(mth, *args, &block)
         else
-          super(mth, *args, **kwargs, &block)
+          super(mth, *args, &block)
         end
       end
+      ruby2_keywords :method_missing if respond_to?(:ruby2_keywords, true)
 
       def respond_to_missing?(mth, include_all = false)
         @delegate.respond_to?(mth, include_all)

--- a/lib/instana/instrumentation/active_record.rb
+++ b/lib/instana/instrumentation/active_record.rb
@@ -8,7 +8,7 @@ module Instana
       IGNORED_SQL = %w[BEGIN COMMIT SET].freeze
       SANITIZE_REGEXP = /('[\s\S][^']*'|\d*\.\d+|\d+|NULL)/i.freeze
 
-      def log(sql, name = 'SQL', binds = [], *args)
+      def log(sql, name = 'SQL', binds = [], *args, **kwargs)
         call_payload = {
           activerecord: {
             adapter: @config[:adapter],
@@ -24,7 +24,7 @@ module Instana
           call_payload[:activerecord][:binds] = mapped
         end
 
-        maybe_trace(call_payload, name) { super(sql, name, binds, *args) }
+        maybe_trace(call_payload, name) { super(sql, name, binds, *args, **kwargs) }
       end
 
       private

--- a/lib/instana/instrumentation/active_record.rb
+++ b/lib/instana/instrumentation/active_record.rb
@@ -8,7 +8,7 @@ module Instana
       IGNORED_SQL = %w[BEGIN COMMIT SET].freeze
       SANITIZE_REGEXP = /('[\s\S][^']*'|\d*\.\d+|\d+|NULL)/i.freeze
 
-      def log(sql, name = 'SQL', binds = [], *args, **kwargs)
+      def log(sql, name = 'SQL', binds = [], *args)
         call_payload = {
           activerecord: {
             adapter: @config[:adapter],
@@ -24,8 +24,9 @@ module Instana
           call_payload[:activerecord][:binds] = mapped
         end
 
-        maybe_trace(call_payload, name) { super(sql, name, binds, *args, **kwargs) }
+        maybe_trace(call_payload, name) { super(sql, name, binds, *args) }
       end
+      ruby2_keywords :log if respond_to?(:ruby2_keywords, true)
 
       private
 

--- a/lib/instana/instrumentation/dalli.rb
+++ b/lib/instana/instrumentation/dalli.rb
@@ -61,13 +61,13 @@ module Instana
         ::Instana::Util.method_alias(klass, :request)
       end
 
-      def request(op, *args)
+      def request(op, *args, **kwargs)
         if ::Instana.tracer.tracing? || ::Instana.tracer.tracing_span?(:memcache)
           info_payload = { :memcache => {} }
           info_payload[:memcache][:server] = "#{@hostname}:#{@port}"
           ::Instana.tracer.log_info(info_payload)
         end
-        super(op, *args)
+        super(op, *args, **kwargs)
       end
     end
   end

--- a/lib/instana/instrumentation/dalli.rb
+++ b/lib/instana/instrumentation/dalli.rb
@@ -61,14 +61,15 @@ module Instana
         ::Instana::Util.method_alias(klass, :request)
       end
 
-      def request(op, *args, **kwargs)
+      def request(op, *args)
         if ::Instana.tracer.tracing? || ::Instana.tracer.tracing_span?(:memcache)
           info_payload = { :memcache => {} }
           info_payload[:memcache][:server] = "#{@hostname}:#{@port}"
           ::Instana.tracer.log_info(info_payload)
         end
-        super(op, *args, **kwargs)
+        super(op, *args)
       end
+      ruby2_keywords :request if respond_to?(:ruby2_keywords, true)
     end
   end
 end

--- a/lib/instana/instrumentation/resque.rb
+++ b/lib/instana/instrumentation/resque.rb
@@ -23,7 +23,7 @@ module Instana
         { :'resque-client' => kvs }
       end
 
-      def enqueue(klass, *args)
+      def enqueue(klass, *args, **kwargs)
         if Instana.tracer.tracing?
           kvs = collect_kvs(:enqueue, klass, args)
 
@@ -32,11 +32,11 @@ module Instana
             super(klass, *args)
           end
         else
-          super(klass, *args)
+          super(klass, *args, **kwargs)
         end
       end
 
-      def enqueue_to(queue, klass, *args)
+      def enqueue_to(queue, klass, *args, **kwargs)
         if Instana.tracer.tracing? && !Instana.tracer.tracing_span?(:'resque-client')
           kvs = collect_kvs(:enqueue_to, klass, args)
           kvs[:Queue] = queue.to_s if queue
@@ -46,19 +46,19 @@ module Instana
             super(queue, klass, *args)
           end
         else
-          super(queue, klass, *args)
+          super(queue, klass, *args, **kwargs)
         end
       end
 
-      def dequeue(klass, *args)
+      def dequeue(klass, *args, **kwargs)
         if Instana.tracer.tracing?
           kvs = collect_kvs(:dequeue, klass, args)
 
           Instana.tracer.trace(:'resque-client', kvs) do
-            super(klass, *args)
+            super(klass, *args, **kwargs)
           end
         else
-          super(klass, *args)
+          super(klass, *args, **kwargs)
         end
       end
     end

--- a/lib/instana/instrumentation/resque.rb
+++ b/lib/instana/instrumentation/resque.rb
@@ -23,7 +23,7 @@ module Instana
         { :'resque-client' => kvs }
       end
 
-      def enqueue(klass, *args, **kwargs)
+      def enqueue(klass, *args)
         if Instana.tracer.tracing?
           kvs = collect_kvs(:enqueue, klass, args)
 
@@ -32,11 +32,12 @@ module Instana
             super(klass, *args)
           end
         else
-          super(klass, *args, **kwargs)
+          super(klass, *args)
         end
       end
+      ruby2_keywords :enqueue if respond_to?(:ruby2_keywords, true)
 
-      def enqueue_to(queue, klass, *args, **kwargs)
+      def enqueue_to(queue, klass, *args)
         if Instana.tracer.tracing? && !Instana.tracer.tracing_span?(:'resque-client')
           kvs = collect_kvs(:enqueue_to, klass, args)
           kvs[:Queue] = queue.to_s if queue
@@ -46,21 +47,23 @@ module Instana
             super(queue, klass, *args)
           end
         else
-          super(queue, klass, *args, **kwargs)
+          super(queue, klass, *args)
         end
       end
+      ruby2_keywords :enqueue_to if respond_to?(:ruby2_keywords, true)
 
-      def dequeue(klass, *args, **kwargs)
+      def dequeue(klass, *args)
         if Instana.tracer.tracing?
           kvs = collect_kvs(:dequeue, klass, args)
 
           Instana.tracer.trace(:'resque-client', kvs) do
-            super(klass, *args, **kwargs)
+            super(klass, *args)
           end
         else
-          super(klass, *args, **kwargs)
+          super(klass, *args)
         end
       end
+      ruby2_keywords :dequeue if respond_to?(:ruby2_keywords, true)
     end
 
     module ResqueWorker

--- a/lib/instana/open_tracing/instana_tracer.rb
+++ b/lib/instana/open_tracing/instana_tracer.rb
@@ -86,9 +86,9 @@ module OpenTracing
       end
     end
 
-    def method_missing(method, *args, &block)
+    def method_missing(method, *args, **kwargs, &block)
       ::Instana.logger.warn { "You are invoking `#{m}` on Instana::Tracer via OpenTracing." }
-      super(method, *args, &block)
+      super(method, *args, **kwargs, &block)
     end
 
     def respond_to_missing?(*)

--- a/lib/instana/open_tracing/instana_tracer.rb
+++ b/lib/instana/open_tracing/instana_tracer.rb
@@ -86,10 +86,11 @@ module OpenTracing
       end
     end
 
-    def method_missing(method, *args, **kwargs, &block)
+    def method_missing(method, *args, &block)
       ::Instana.logger.warn { "You are invoking `#{m}` on Instana::Tracer via OpenTracing." }
-      super(method, *args, **kwargs, &block)
+      super(method, *args, &block)
     end
+    ruby2_keywords :method_missing if respond_to?(:ruby2_keywords, true)
 
     def respond_to_missing?(*)
       super(method)

--- a/lib/instana/tracer.rb
+++ b/lib/instana/tracer.rb
@@ -8,9 +8,9 @@ module Instana
   class Tracer
     # Support ::Instana::Tracer.xxx call style for the instantiated tracer
     class << self
-      def method_missing(method, *args, &block)
+      def method_missing(method, *args, **kwargs, &block)
         if ::Instana.tracer.respond_to?(method)
-          ::Instana.tracer.send(method, *args, &block)
+          ::Instana.tracer.send(method, *args, **kwargs, &block)
         else
           super
         end

--- a/lib/instana/tracer.rb
+++ b/lib/instana/tracer.rb
@@ -8,13 +8,14 @@ module Instana
   class Tracer
     # Support ::Instana::Tracer.xxx call style for the instantiated tracer
     class << self
-      def method_missing(method, *args, **kwargs, &block)
+      def method_missing(method, *args, &block)
         if ::Instana.tracer.respond_to?(method)
-          ::Instana.tracer.send(method, *args, **kwargs, &block)
+          ::Instana.tracer.send(method, *args, &block)
         else
           super
         end
       end
+      ruby2_keywords :method_missing if respond_to?(:ruby2_keywords, true)
     end
 
     def initialize(logger: Instana.logger)

--- a/lib/opentracing.rb
+++ b/lib/opentracing.rb
@@ -17,8 +17,8 @@ module OpenTracing
 
     attr_accessor :global_tracer
 
-    def method_missing(method_name, *args, &block)
-      @global_tracer.send(method_name, *args, &block)
+    def method_missing(method_name, *args, **kwargs, &block)
+      @global_tracer.send(method_name, *args, **kwargs, &block)
     end
 
     def respond_to_missing?(name, all)

--- a/lib/opentracing.rb
+++ b/lib/opentracing.rb
@@ -17,9 +17,10 @@ module OpenTracing
 
     attr_accessor :global_tracer
 
-    def method_missing(method_name, *args, **kwargs, &block)
-      @global_tracer.send(method_name, *args, **kwargs, &block)
+    def method_missing(method_name, *args, &block)
+      @global_tracer.send(method_name, *args, &block)
     end
+    ruby2_keywords :method_missing if respond_to?(:ruby2_keywords, true)
 
     def respond_to_missing?(name, all)
       @global_tracer.respond_to?(name, all)


### PR DESCRIPTION
Ruby 3.0 introduced the [separation of positional and keyword arguments](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0):

### Handling argument delegation

#### Ruby 2.6 or prior

In Ruby 2, you can write a delegation method by accepting a `*rest` argument and a `&block` argument, and passing the two to the target method. In this behavior, the keyword arguments are also implicitly handled by the automatic conversion between positional and keyword arguments.

```ruby
def foo(*args, &block)
  target(*args, &block)
end
```

#### Ruby 3

You need to explicitly delegate keyword arguments.

```ruby
def foo(*args, **kwargs, &block)
  target(*args, **kwargs, &block)
end
```

### Changes in this pull request

This is a proposal to update delegate methods in this codebase (non-exhaustive), where the explicit delegation of keyword arguments is warranted, as per [the Ruby 3.0 guidelines](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/). 