### PR TITLE
feat: improve robustness of custom service naming

### DIFF
--- a/lib/instana/instrumentation/rack.rb
+++ b/lib/instana/instrumentation/rack.rb
@@ -13,8 +13,7 @@ module Instana
     def call(env)
       req = InstrumentedRequest.new(env)
       kvs = {
-        http: req.request_tags,
-        service: ENV['INSTANA_SERVICE_NAME']
+        http: req.request_tags
       }.reject { |_, v| v.nil? }
 
       current_span = ::Instana.tracer.log_start_or_continue(:rack, {}, req.incoming_context)

--- a/lib/instana/instrumentation/resque.rb
+++ b/lib/instana/instrumentation/resque.rb
@@ -69,9 +69,6 @@ module Instana
         kvs[:'resque-worker'] = {}
 
         begin
-          if ENV.key?('INSTANA_SERVICE_NAME')
-            kvs[:service] = ENV['INSTANA_SERVICE_NAME']
-          end
           kvs[:'resque-worker'][:job] = job.payload['class'].to_s
           kvs[:'resque-worker'][:queue] = job.queue
         rescue => e

--- a/lib/instana/instrumentation/sidekiq-worker.rb
+++ b/lib/instana/instrumentation/sidekiq-worker.rb
@@ -18,10 +18,6 @@ module Instana
           kv_payload[:'sidekiq-worker'][:'redis-url'] = "#{opts[:host]}:#{opts[:port]}"
         end
 
-        if ENV.key?('INSTANA_SERVICE_NAME')
-          kv_payload[:service] = ENV['INSTANA_SERVICE_NAME']
-        end
-
         context = {}
         if msg.key?('X-Instana-T')
           trace_id = msg.delete('X-Instana-T')

--- a/lib/instana/tracing/span.rb
+++ b/lib/instana/tracing/span.rb
@@ -55,6 +55,10 @@ module Instana
 
       @data[:data] = {}
 
+      if ENV.key?('INSTANA_SERVICE_NAME')
+        @data[:data][:service] = ENV['INSTANA_SERVICE_NAME']
+      end
+
       # Entity Source
       @data[:f] = ::Instana.agent.source
       # Start time


### PR DESCRIPTION
Previously, we only added span.data.service to _entry_ spans (when the environment variable INSTANA_SERVICE_NAME is set). The requirements around this have changed, now we add this annotation to _all_ spans (but still only if it has been explicitly configured).

See also:
* https://github.ibm.com/instana/technical-documentation/pull/290/files
* https://instana.slack.com/archives/GBS2G15GD/p1675160462737709