### PR TITLE
Fix process memory metric UOM

### DIFF
--- a/instana.gemspec
+++ b/instana.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.test_files    = Dir.glob("{test}/**/*.rb")
 
-  spec.required_ruby_version = '>= 2.1'
+  spec.required_ruby_version = '>= 2.4'
   spec.platform      = defined?(JRUBY_VERSION) ? 'java' : Gem::Platform::RUBY
 
   spec.add_development_dependency "bundler", "~> 2.0"

--- a/lib/instana/backend/process_info.rb
+++ b/lib/instana/backend/process_info.rb
@@ -51,7 +51,7 @@ module Instana
         if RbConfig::CONFIG['host_os'].include?('darwin')
           rss / 1024
         else
-          rss * 4096
+          rss * 4 # This has to be 4KB not 4096B if we want KB 
         end
       end
 

--- a/lib/instana/snapshot/ruby_process.rb
+++ b/lib/instana/snapshot/ruby_process.rb
@@ -40,7 +40,7 @@ module Instana
           exec_args: process.arguments,
           gc: Backend::GCSnapshot.instance.report,
           thread: {count: ::Thread.list.count},
-          memory: {rss_size: proc_table.rss / 1024} # Bytes to Kilobytes
+          memory: {rss_size: process.memory_used } # Kilobytes
         }
       end
     end

--- a/test/backend/process_info_test.rb
+++ b/test/backend/process_info_test.rb
@@ -74,7 +74,7 @@ class ProcessInfoTest < Minitest::Test
   def test_linux_memory_used
     host_os = RbConfig::CONFIG['host_os']
     RbConfig::CONFIG['host_os'] = 'linux'
-    # 1 page memory page is 4 kb
+    # 1 memory page is 4 kb
     subject = Instana::Backend::ProcessInfo.new(OpenStruct.new(rss: 1))
     assert_equal 4, subject.memory_used
   ensure

--- a/test/backend/process_info_test.rb
+++ b/test/backend/process_info_test.rb
@@ -64,7 +64,7 @@ class ProcessInfoTest < Minitest::Test
   def test_osx_memory_used
     host_os = RbConfig::CONFIG['host_os']
     RbConfig::CONFIG['host_os'] = 'darwin'
-
+   
     subject = Instana::Backend::ProcessInfo.new(OpenStruct.new(rss: 1024))
     assert_equal 1, subject.memory_used
   ensure
@@ -74,9 +74,9 @@ class ProcessInfoTest < Minitest::Test
   def test_linux_memory_used
     host_os = RbConfig::CONFIG['host_os']
     RbConfig::CONFIG['host_os'] = 'linux'
-
+    # 1 page memory page is 4 kb
     subject = Instana::Backend::ProcessInfo.new(OpenStruct.new(rss: 1))
-    assert_equal 4096, subject.memory_used
+    assert_equal 4, subject.memory_used
   ensure
     RbConfig::CONFIG['host_os'] = host_os
   end


### PR DESCRIPTION
Currently the sensor reports process memory usage in bytes for Linux, and in Kilobytes for macos. Then the UI shows memory usage in Gigabytes instead of megabytes. This makes the sensor return always a value in KB.
I also updated the specfile so it reflects current ruby version requirements (>2.4)
This fixes #283 and #287