### PR TITLE
fix: Change unit of memory to match the UI

### DIFF
--- a/lib/instana/backend/host_agent_reporting_observer.rb
+++ b/lib/instana/backend/host_agent_reporting_observer.rb
@@ -111,7 +111,8 @@ module Instana
           proc_table = Sys::ProcTable.ps(pid: Process.pid)
           process = ProcessInfo.new(proc_table)
           payload[:exec_args] = process.arguments
-          payload[:memory] = {rss_size: process.memory_used}
+          payload[:memory] = {rss_size: process.memory_used / 1024} # Bytes to Kilobytes like in ruby_process.rb
+
         end
 
         if ::Instana.config[:metrics][:gc][:enabled]

--- a/lib/instana/backend/process_info.rb
+++ b/lib/instana/backend/process_info.rb
@@ -49,7 +49,7 @@ module Instana
 
       def memory_used
         if RbConfig::CONFIG['host_os'].include?('darwin')
-          rss / 1024
+          rss
         else
           rss * 4096
         end

--- a/test/backend/process_info_test.rb
+++ b/test/backend/process_info_test.rb
@@ -65,7 +65,7 @@ class ProcessInfoTest < Minitest::Test
     host_os = RbConfig::CONFIG['host_os']
     RbConfig::CONFIG['host_os'] = 'darwin'
 
-    subject = Instana::Backend::ProcessInfo.new(OpenStruct.new(rss: 1024))
+    subject = Instana::Backend::ProcessInfo.new(OpenStruct.new(rss: 1))
     assert_equal 1, subject.memory_used
   ensure
     RbConfig::CONFIG['host_os'] = host_os


### PR DESCRIPTION
Problem:
The UI in `rubyRuntimePlatform/Dashboard/Content.js` uses the `formatter: kiloBytesTwoDecimalPlaces` for displaying the value in `plugins.rubyRuntimePlatform.dashboard.memory`.

Which essentially treats the unit of the value as a `Kilobyte`, This has not changed in a long long time.
In the ruby-sensor however in `c49f7dfe191f1cc3c0278042ddb76cbc5ff31181` things have changed,
the rss value propagation has been separated on the two mainly supported platforms `darwin` and  `linux` .
The orignal code previous to `c49f7dfe191f1cc3c0278042ddb76cbc5ff31181` was converting
the `rss` value to `kibibyte` on the top level, before sending the metrics.

After  `c49f7dfe191f1cc3c0278042ddb76cbc5ff31181`, for host agents (non-serverless),
the `rss` for `darwin` is read in `byte` and then immediately converted to `kibibyte`, but for `linux` the `rss` is read in `number of pages`, and converted to `bytes` instead of `kibibyte` with the `4096` byte page constant.
And the top level conversion was removed. 
This left the MacOS reporting in  `kibibyte` while Linux reporting in `bytes`.

This commit restores the original top level conversion, and makes sure that before the conversion everything is in `bytes` on both OS, this aligns with `ruby_process.rb` , which is still used for serverless, and also keeps the values in `bytes` and only converts them before sending.

