### PR TITLE
fix: Do not announce "nil" pid

### DIFF
--- a/lib/instana/backend/process_info.rb
+++ b/lib/instana/backend/process_info.rb
@@ -18,7 +18,7 @@ module Instana
       end
 
       def parent_pid
-        if in_container? && sched_pid != pid
+        if in_container? && !sched_pid.nil?
           sched_pid
         else
           pid

--- a/lib/instana/version.rb
+++ b/lib/instana/version.rb
@@ -2,6 +2,6 @@
 # (c) Copyright Instana Inc. 2016
 
 module Instana
-  VERSION = "1.209.5"
+  VERSION = "1.209.6"
   VERSION_FULL = "instana-#{VERSION}"
 end


### PR DESCRIPTION
Prevents `NullPointerException` in the agent, because of announcing with `Announcement request: RubyProcess{pid='null', ...`.
Which happens on kernels where `/proc/[pid]/sched`is not available.
