### PR TITLE
fix: handle newer format versions in traceparent with additional fields

### DIFF
--- a/lib/instana/config.rb
+++ b/lib/instana/config.rb
@@ -53,8 +53,8 @@ module Instana
       # ::Instana.config[:sanitize_sql] = false
       @config[:sanitize_sql] = true
 
-      # W3 Trace Context Support
-      @config[:w3_trace_correlation] = ENV['INSTANA_DISABLE_W3C_TRACE_CORRELATION'].nil?
+      # W3C Trace Context Support
+      @config[:w3c_trace_correlation] = ENV['INSTANA_DISABLE_W3C_TRACE_CORRELATION'].nil?
 
       @config[:post_fork_proc] = proc { ::Instana.agent.spawn_background_thread }
 

--- a/lib/instana/instrumentation/instrumented_request.rb
+++ b/lib/instana/instrumentation/instrumented_request.rb
@@ -9,7 +9,7 @@ require 'rack/request'
 
 module Instana
   class InstrumentedRequest < Rack::Request
-    W3_TRACE_PARENT_FORMAT = /00-(?<trace>[0-9a-f]+)-(?<parent>[0-9a-f]+)-(?<flags>[0-9a-f]+)/.freeze
+    W3_TRACE_PARENT_FORMAT = /[0-9a-f][0-9a-e]-(?<trace>[0-9a-f]{32})-(?<parent>[0-9a-f]{16})-(?<flags>[0-9a-f]{2})/.freeze
     INSTANA_TRACE_STATE = /in=(?<trace>[0-9a-f]+);(?<span>[0-9a-f]+)/.freeze
 
     def skip_trace?

--- a/test/instrumentation/rack_instrumented_request_test.rb
+++ b/test/instrumentation/rack_instrumented_request_test.rb
@@ -29,7 +29,7 @@ class RackInstrumentedRequestTest < Minitest::Test
     expected = {
       trace_id: id,
       span_id: id,
-      from_w3: false,
+      from_w3c: false,
       level: '1'
     }
 
@@ -37,7 +37,7 @@ class RackInstrumentedRequestTest < Minitest::Test
     refute req.continuing_from_trace_parent?
   end
 
-  def test_incoming_w3_context
+  def test_incoming_w3c_context
     req = Instana::InstrumentedRequest.new(
       'HTTP_X_INSTANA_L' => '1',
       'HTTP_TRACEPARENT' => '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01'
@@ -48,7 +48,7 @@ class RackInstrumentedRequestTest < Minitest::Test
       external_state: nil,
       trace_id: 'a3ce929d0e0e4736',
       span_id: '00f067aa0ba902b7',
-      from_w3: true,
+      from_w3c: true,
       level: '1'
     }
 
@@ -56,7 +56,7 @@ class RackInstrumentedRequestTest < Minitest::Test
     assert req.continuing_from_trace_parent?
   end
 
-  def test_incoming_w3_context_newer_version_additional_fields
+  def test_incoming_w3c_context_newer_version_additional_fields
     req = Instana::InstrumentedRequest.new(
       'HTTP_TRACEPARENT' => 'fe-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01-abcdefg'
     )
@@ -66,7 +66,7 @@ class RackInstrumentedRequestTest < Minitest::Test
       external_state: nil,
       trace_id: 'a3ce929d0e0e4736',
       span_id: '00f067aa0ba902b7',
-      from_w3: true,
+      from_w3c: true,
       level: '1'
     }
 
@@ -74,7 +74,7 @@ class RackInstrumentedRequestTest < Minitest::Test
     assert req.continuing_from_trace_parent?
   end
 
-  def test_incoming_w3_context_unknown_flags
+  def test_incoming_w3c_context_unknown_flags
     req = Instana::InstrumentedRequest.new(
       'HTTP_X_INSTANA_L' => '1',
       'HTTP_TRACEPARENT' => '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-ff'
@@ -85,7 +85,7 @@ class RackInstrumentedRequestTest < Minitest::Test
       external_state: nil,
       trace_id: 'a3ce929d0e0e4736',
       span_id: '00f067aa0ba902b7',
-      from_w3: true,
+      from_w3c: true,
       level: '1'
     }
 
@@ -118,7 +118,7 @@ class RackInstrumentedRequestTest < Minitest::Test
     refute req.continuing_from_trace_parent?
   end
 
-  def test_incoming_invalid_w3_context
+  def test_incoming_invalid_w3c_context
     req = Instana::InstrumentedRequest.new(
       'HTTP_X_INSTANA_L' => '1',
       'HTTP_TRACEPARENT' => '00-XXa3ce929d0e0e4736-00f67aa0ba902b7-01'
@@ -132,7 +132,7 @@ class RackInstrumentedRequestTest < Minitest::Test
     refute req.continuing_from_trace_parent?
   end
 
-  def test_incoming_w3_state
+  def test_incoming_w3c_state
     req = Instana::InstrumentedRequest.new(
       'HTTP_TRACESTATE' => 'a=12345,in=123;abe,c=[+]'
     )

--- a/test/instrumentation/rack_test.rb
+++ b/test/instrumentation/rack_test.rb
@@ -69,7 +69,7 @@ class RackTest < Minitest::Test
     assert last_response.headers.key?("Server-Timing")
     assert last_response.headers["Server-Timing"] == "intid;desc=#{::Instana::Util.id_to_header(rack_span[:t])}"
 
-    # W3 Trace Context
+    # W3C Trace Context
     assert_equal "00-#{rack_span[:t].rjust(32, '0')}-#{rack_span[:s]}-01", last_response.headers["Traceparent"]
     assert_equal "in=#{rack_span[:t]};#{rack_span[:s]}", last_response.headers["Tracestate"]
 
@@ -301,7 +301,7 @@ class RackTest < Minitest::Test
     assert_equal true, first_span[:sy]
   end
 
-  def test_basic_get_with_w3_trace
+  def test_basic_get_with_w3c_trace
     clear_all!
 
     header 'TRACEPARENT', '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01'
@@ -321,9 +321,9 @@ class RackTest < Minitest::Test
     assert first_span[:tp]
   end
 
-  def test_basic_get_with_w3_disabled
+  def test_basic_get_with_w3c_disabled
     clear_all!
-    ::Instana.config[:w3_trace_correlation] = false
+    ::Instana.config[:w3c_trace_correlation] = false
 
     header 'TRACEPARENT', '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01'
 
@@ -336,7 +336,7 @@ class RackTest < Minitest::Test
     first_span = spans.first
     assert_equal :rack, first_span[:n]
     refute first_span[:tp]
-    ::Instana.config[:w3_trace_correlation] = true
+    ::Instana.config[:w3c_trace_correlation] = true
   end
 
   def test_skip_trace


### PR DESCRIPTION
The new test case in the tracer test suite is also failing for Ruby. (At first I thought it would not but that was only because the test suite accidentally ran an outdated set of test cases. This is fixed now.)

~~This PR should fix it. (Not tested locally with the test suite yet, though.)~~

Update 2023-05-22: This PR fixes that. I have tested this locally with the tracer test suite with the changes from this branch.