### PR TITLE
fix(graphql): Use class name if the object has no 'name' instance variable

### DIFF
--- a/lib/instana/instrumentation/graphql.rb
+++ b/lib/instana/instrumentation/graphql.rb
@@ -63,7 +63,20 @@ module Instana
         return [] unless parent.respond_to?(method)
 
         parent.send(method).map do |field|
-          [{object: parent.name, field: field.name}] + walk_fields(field, method)
+          # Certain types like GraphQL::Language::Nodes::InlineFragment
+          # have no "name" instance variable defined,
+          # in such case we use the class's name
+          parent_name = if parent.instance_variable_defined?(:@name)
+                          parent.name
+                        else
+                          parent.class.name.split('::').last
+                        end
+          field_name = if field.instance_variable_defined?(:@name)
+                         field.name
+                       else
+                         field.class.name.split('::').last
+                       end
+          [{object: parent_name, field: field_name}] + walk_fields(field, method)
         end.flatten
       end
 

--- a/test/instrumentation/graphql_test.rb
+++ b/test/instrumentation/graphql_test.rb
@@ -9,6 +9,27 @@ class GraphqlTest < Minitest::Test
     field :action, String, null: false
   end
 
+  class JobType < GraphQL::Schema::Object
+    field :id, ID, null: false
+    field :name, String, null: false
+    field :description, String, null: false
+  end
+
+  class TaskJobUnion < GraphQL::Schema::Union
+    description "A union type for Task and Job"
+    possible_types TaskType, JobType
+
+    def self.resolve_type(object, _context)
+      if !object.action.nil?
+        TaskType
+      elsif !object.description?
+        JobType
+      else
+        raise("Unexpected object: #{object}")
+      end
+    end
+  end
+
   class NewTaskType < GraphQL::Schema::Mutation
     argument :action, String, required: true
     field :task, TaskType, null: true
@@ -22,6 +43,8 @@ class GraphqlTest < Minitest::Test
 
   class QueryType < GraphQL::Schema::Object
     field :tasks, TaskType.connection_type, null: false
+    field :jobs, JobType.connection_type, null: false
+    field :tasksorjobs, TaskJobUnion.connection_type, null: false
 
     def tasks()
       [
@@ -30,6 +53,23 @@ class GraphqlTest < Minitest::Test
         OpenStruct.new(id: '2', action: 'Sample 02'),
         OpenStruct.new(id: '3', action: 'Sample 03'),
         OpenStruct.new(id: '4', action: 'Sample 04')
+      ]
+    end
+
+    def jobs()
+      [
+        OpenStruct.new(id: '0', name: 'Name 00', description: 'Desc 00'),
+        OpenStruct.new(id: '1', name: 'Name 01', description: 'Desc 01'),
+        OpenStruct.new(id: '2', name: 'Name 02', description: 'Desc 02'),
+        OpenStruct.new(id: '3', name: 'Name 03', description: 'Desc 03'),
+        OpenStruct.new(id: '4', name: 'Name 04', description: 'Desc 04')
+      ]
+    end
+
+    def tasksorjobs()
+      [
+        OpenStruct.new(id: '0', action: 'Task 00'),
+        OpenStruct.new(id: '0', name: 'Job 00', description: 'Job Desc 00')
       ]
     end
   end
@@ -115,6 +155,50 @@ class GraphqlTest < Minitest::Test
           "nodes" => [{"action" => "Sample 00"}, {"action" => "Sample 01"},
                       {"action" => "Sample 02"}, {"action" => "Sample 03"},
                       {"action" => "Sample 04"}]
+        }
+      }
+    }
+
+    results = Instana.tracer.start_or_continue_trace('graphql-test') { Schema.execute(query) }
+    query_span, root_span = *Instana.processor.queued_spans
+
+    assert_equal expected_results, results.to_h
+    assert_equal :sdk, root_span[:n]
+    assert_equal :'graphql.server', query_span[:n]
+    assert_equal expected_data, query_span[:data][:graphql]
+  end
+
+  def test_query_union_with_fragment
+    clear_all!
+
+    query = "
+    query QueryUnionWithFragment {
+      tasksorjobs {
+        nodes {
+          ... on Task {
+            action
+          }
+          ... on Job {
+            name
+            description
+          }
+        }
+      }
+    }"
+
+    expected_data = {
+      :operationName => "QueryUnionWithFragment",
+      :operationType => "query",
+      :arguments => {},
+      :fields => { "tasksorjobs" => ["nodes"],
+                   "nodes" => ["InlineFragment", "InlineFragment"],
+                   "InlineFragment" => %w[action name description]}
+    }
+    expected_results = {
+      "data" => {
+        "tasksorjobs" => {
+          "nodes" => [{"action" => "Task 00"},
+                      {"name" => "Job 00", "description" => "Job Desc 00"}]
         }
       }
     }


### PR DESCRIPTION
Fixes: TS012739464 and at least partially TS012739440 as well