### PR TITLE
feat: Add support for latest Dalli versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -305,6 +305,8 @@ workflows:
                 - "./gemfiles/cuba_30.gemfile"
                 - "./gemfiles/cuba_40.gemfile"
                 - "./gemfiles/dalli_20.gemfile"
+                - "./gemfiles/dalli_30.gemfile"
+                - "./gemfiles/dalli_32.gemfile"
                 - "./gemfiles/excon_02.gemfile"
                 - "./gemfiles/excon_079.gemfile"
                 - "./gemfiles/excon_100.gemfile"

--- a/gemfiles/dalli_30.gemfile
+++ b/gemfiles/dalli_30.gemfile
@@ -1,0 +1,15 @@
+# (c) Copyright IBM Corp. 2023
+
+source "https://rubygems.org"
+
+gem "rake"
+gem "minitest", "5.9.1"
+gem "minitest-reporters"
+gem "webmock"
+gem "puma"
+gem "rubocop", "~> 1.9"
+gem "rack-test"
+gem "simplecov", "~> 0.21.2"
+gem "dalli", "< 3.1.3"
+
+gemspec path: "../"

--- a/gemfiles/dalli_32.gemfile
+++ b/gemfiles/dalli_32.gemfile
@@ -1,0 +1,15 @@
+# (c) Copyright IBM Corp. 2023
+
+source "https://rubygems.org"
+
+gem "rake"
+gem "minitest", "5.9.1"
+gem "minitest-reporters"
+gem "webmock"
+gem "puma"
+gem "rubocop", "~> 1.9"
+gem "rack-test"
+gem "simplecov", "~> 0.21.2"
+gem "dalli", ">= 3.2.5"
+
+gemspec path: "../"

--- a/lib/instana/activators/dalli.rb
+++ b/lib/instana/activators/dalli.rb
@@ -5,16 +5,22 @@ module Instana
   module Activators
     class Dalli < Activator
       def can_instrument?
-        defined?(::Dalli::Client) &&
-          defined?(::Dalli::Server) &&
+        defined?(::Dalli::Protocol::Base || defined?(::Dalli::Server)) &&
+          defined?(::Dalli::Client) &&
           Instana.config[:dalli][:enabled]
       end
 
       def instrument
         require 'instana/instrumentation/dalli'
-
+        dalli_version = Gem::Specification.find_by_name('dalli').version
         ::Dalli::Client.prepend ::Instana::Instrumentation::Dalli
-        ::Dalli::Server.prepend ::Instana::Instrumentation::DalliServer
+        if dalli_version < Gem::Version.new('3.0')
+          ::Dalli::Server.prepend ::Instana::Instrumentation::DalliRequestHandler
+        elsif dalli_version >= Gem::Version.new('3.0') && dalli_version < Gem::Version.new('3.1.3')
+          ::Dalli::Protocol::Binary.prepend ::Instana::Instrumentation::DalliRequestHandler
+        else
+          ::Dalli::Protocol::Base.prepend ::Instana::Instrumentation::DalliRequestHandler
+        end
 
         true
       end

--- a/lib/instana/instrumentation/dalli.rb
+++ b/lib/instana/instrumentation/dalli.rb
@@ -56,7 +56,7 @@ module Instana
       end
     end
 
-    module DalliServer
+    module DalliRequestHandler
       def self.included(klass)
         ::Instana::Util.method_alias(klass, :request)
       end
@@ -64,7 +64,7 @@ module Instana
       def request(op, *args)
         if ::Instana.tracer.tracing? || ::Instana.tracer.tracing_span?(:memcache)
           info_payload = { :memcache => {} }
-          info_payload[:memcache][:server] = "#{@hostname}:#{@port}"
+          info_payload[:memcache][:server] = "#{hostname}:#{port}"
           ::Instana.tracer.log_info(info_payload)
         end
         super(op, *args)


### PR DESCRIPTION
The `Dalli::Server` class has become deprecated.

From `3.0.0` up until `3.1.12` the same logic is in
`Dalli::Protocol::Binary`.

Starting with `3.1.12`, the request handling from
`Dalli::Protocol::Binary` has been moved to `Dalli::Protocol::Base`.

The `@hostname` and `@port` fields are dropped between in `v3.1.1`,
and only the `:hostname` and `:port` accessors  are available,
but those have been available even earlier, definitely
in the `2.0.0`, which is the oldest supported.
