### PR TITLE
fix: The spec doesn't set upper limit for ec=1 if code>=500

### DIFF
--- a/lib/instana/instrumentation/excon.rb
+++ b/lib/instana/instrumentation/excon.rb
@@ -60,7 +60,7 @@ module Instana
           status = datum[:response][:status]
         end
 
-        if status.between?(500, 511)
+        if status >= 500
           # Because of the 5xx response, we flag this span as errored but
           # without a backtrace (no exception)
           ::Instana.tracer.log_error(nil)

--- a/lib/instana/instrumentation/net-http.rb
+++ b/lib/instana/instrumentation/net-http.rb
@@ -51,7 +51,7 @@ module Instana
         response = super(*args, &block)
 
         kv_payload[:http][:status] = response.code
-        if response.code.to_i.between?(500, 511)
+        if response.code.to_i >= 500
           # Because of the 5xx response, we flag this span as errored but
           # without a backtrace (no exception)
           ::Instana.tracer.log_error(nil)

--- a/lib/instana/instrumentation/rack.rb
+++ b/lib/instana/instrumentation/rack.rb
@@ -48,7 +48,7 @@ module Instana
         # See Rack Spec: https://www.rubydoc.info/github/rack/rack/file/SPEC#label-The+Status
         kvs[:http][:status] = status.to_i
 
-        if status.to_i.between?(500, 511)
+        if status.to_i >= 500
           # Because of the 5xx response, we flag this span as errored but
           # without a backtrace (no exception)
           ::Instana.tracer.log_error(nil)


### PR DESCRIPTION
Quote from the [spec](
https://github.ibm.com/instana/technical-documentation/tree/master/tracing/specification#capturing-errors-on-http-spans):

> For HTTP exit and entry spans alike, if a full request/response cycle has happened (which implies that an HTTP status code is present): If the HTTP status code is >= 500, the associated span MUST be marked as an error via span.ec.

This means that there is no upper limit, and this should apply to custom status codes as well, which might be above `511`, or even `599`.
