### PR TITLE
fix(sinatra): Ensure that `mustermann_opts' is always defined

### DIFF
--- a/lib/instana/activators/sinatra.rb
+++ b/lib/instana/activators/sinatra.rb
@@ -12,6 +12,9 @@ module Instana
         require 'instana/frameworks/sinatra'
 
         ::Sinatra::Base.use ::Instana::Rack
+        unless ::Sinatra::Base.respond_to?(:mustermann_opts)
+          ::Sinatra::Base.set :mustermann_opts, {}
+        end
         ::Sinatra::Base.register ::Instana::SinatraPathTemplateExtractor
 
         true


### PR DESCRIPTION
And thus prevent crashes, when the instana thread calls sinatra/base.rb's compile function, which relies on this variable being initialized to an empty hash.

Backtarce was:

/usr/local/bundle/gems/sinatra-4.0.0/lib/sinatra/base.rb:1811:in `compile': undefined local variable or method `mustermann_opts' for Sinatra::Base:Class (NameError)

        Mustermann.new(path, **mustermann_opts.merge(route_mustermann_opts))
                               ^^^^^^^^^^^^^^^
        from /usr/local/bundle/gems/sinatra-4.0.0/lib/sinatra/base.rb:1798:in `compile!'
        from /usr/local/bundle/gems/sinatra-4.0.0/lib/sinatra/base.rb:1494:in `add_filter'
        from /usr/local/bundle/gems/sinatra-4.0.0/lib/sinatra/base.rb:1489:in `after'
        from /opt/instana/instrumentation/ruby/ruby/3.2.0/gems/instana-1.213.1/lib/instana/frameworks/sinatra.rb:16:in `store_path_template'
        from /opt/instana/instrumentation/ruby/ruby/3.2.0/gems/instana-1.213.1/lib/instana/frameworks/sinatra.rb:12:in `extended'
        from /usr/local/bundle/gems/sinatra-4.0.0/lib/sinatra/base.rb:1563:in `extend'
        from /usr/local/bundle/gems/sinatra-4.0.0/lib/sinatra/base.rb:1563:in `block in register'
        from /usr/local/bundle/gems/sinatra-4.0.0/lib/sinatra/base.rb:1562:in `each'
        from /usr/local/bundle/gems/sinatra-4.0.0/lib/sinatra/base.rb:1562:in `register'
        from /opt/instana/instrumentation/ruby/ruby/3.2.0/gems/instana-1.213.1/lib/instana/activators/sinatra.rb:15:in `instrument'
        from /opt/instana/instrumentation/ruby/ruby/3.2.0/gems/instana-1.213.1/lib/instana/activator.rb:41:in `call'
        from /opt/instana/instrumentation/ruby/ruby/3.2.0/gems/instana-1.213.1/lib/instana/activator.rb:22:in `each'
        from /opt/instana/instrumentation/ruby/ruby/3.2.0/gems/instana-1.213.1/lib/instana/activator.rb:22:in `partition'
        from /opt/instana/instrumentation/ruby/ruby/3.2.0/gems/instana-1.213.1/lib/instana/activator.rb:22:in `call'
        from /opt/instana/instrumentation/ruby/ruby/3.2.0/gems/instana-1.213.1/lib/instana/activator.rb:12:in `block in start'
        from /usr/local/bundle/gems/sinatra-4.0.0/lib/sinatra/main.rb:28:in `<module:Sinatra>'
        from /usr/local/bundle/gems/sinatra-4.0.0/lib/sinatra/main.rb:3:in `<top (required)>'
        from <internal:/usr/local/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
        from <internal:/usr/local/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
        from /usr/local/bundle/gems/sinatra-4.0.0/lib/sinatra.rb:3:in `<top (required)>'
        from <internal:/usr/local/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
        from <internal:/usr/local/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
        from myapp.rb:2:in `<main>'