### PR TITLE
fix: Prevent usage of Oj once requiring it already raised an exception

### DIFF
--- a/lib/instana/backend/request_client.rb
+++ b/lib/instana/backend/request_client.rb
@@ -8,8 +8,10 @@ require 'json'
 # :nocov:
 begin
   require 'oj'
+  INSTANA_USE_OJ = true
 rescue LoadError => _e
   Instana.logger.warn("Unable to load Oj.")
+  INSTANA_USE_OJ = false
 end
 # :nocov:
 
@@ -66,7 +68,7 @@ module Instana
 
       def encode_body(data)
         # :nocov:
-        defined?(Oj) ? Oj.dump(data, mode: :strict) : JSON.dump(data)
+        INSTANA_USE_OJ ? Oj.dump(data, mode: :strict) : JSON.dump(data)
         # :nocov:
       end
     end


### PR DESCRIPTION
Fixes the following exception, which happens,
when the require statement has raised an exception, but only after the 'Oj' name is already defined.

````
E, [2024-04-29T13:33:24.549280 #108] ERROR -- : undefined method `dump' for Oj:Module

        defined?(Oj) ? Oj.dump(data, mode: :strict) : JSON.dump(data)
                         ^^^^^
Did you mean?  dup
````