### PR TITLE
ci: Increase tekton PipelineRun timeout

### DIFF
--- a/.tekton/pipelinerun.yaml
+++ b/.tekton/pipelinerun.yaml
@@ -3,6 +3,8 @@ kind: PipelineRun
 metadata:
   name: ruby-tracer-ci-pipeline-run
 spec:
+  timeouts:
+    pipeline: "2h"
   params:
   - name: revision
     value: "tekton"

--- a/.tekton/scheduled-eventlistener.yaml
+++ b/.tekton/scheduled-eventlistener.yaml
@@ -19,6 +19,8 @@ spec:
         # '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'
         name: ruby-tracer-scheduled-ci-pipeline-$(tt.params.date-time-normalized)-$(tt.params.git-commit-short-sha)
       spec:
+        timeouts:
+          pipeline: "2h"
         params:
         - name: revision
           value: master


### PR DESCRIPTION
### Why?
The current `ruby-tracer-scheduled-ci-pipeline` takes ~55 minutes to complete. But sometimes it takes more than a hour which exceeds the default timeout of `1h`.

<img width="1528" alt="Screenshot 2024-05-28 at 10 46 21 PM" src="https://github.com/instana/ruby-sensor/assets/52667690/2e945bfa-6a47-4d6a-b459-655df4c66219">
