### PR TITLE
test: Fix deprecation warning on incorrect assertion

### DIFF
--- a/test/instrumentation/sidekiq-client_test.rb
+++ b/test/instrumentation/sidekiq-client_test.rb
@@ -68,8 +68,8 @@ class SidekiqClientTest < Minitest::Test
     assert_equal 'SidekiqJobOne', job_message['class']
     assert_equal [1, 2, 3], job_message['args']
     assert_equal false, job_message['retry']
-    assert_equal false, job_message['X-Instana-T'].nil?
-    assert_equal false, job_message['X-Instana-S'].nil?
+    refute_nil   job_message['X-Instana-T']
+    refute_nil   job_message['X-Instana-S']
   end
 
   def assert_normal_trace_recorded(job)
@@ -102,7 +102,7 @@ class SidekiqClientTest < Minitest::Test
 
     assert_equal :'sidekiq-client', second_span[:n]
     assert_equal true, second_span[:error]
-    assert_equal false, second_span[:stack].nil?
+    refute_nil   second_span[:stack]
 
     assert_equal 'some_random_queue', second_span[:data][:'sidekiq-client'][:queue]
     assert_equal 'SidekiqJobTwo', second_span[:data][:'sidekiq-client'][:job]

--- a/test/instrumentation/sidekiq-worker_test.rb
+++ b/test/instrumentation/sidekiq-worker_test.rb
@@ -156,7 +156,7 @@ class SidekiqServerTest < Minitest::Test
     assert_equal 'important', worker_span[:data][:'sidekiq-worker'][:queue]
     assert_equal 'SidekiqJobOne', worker_span[:data][:'sidekiq-worker'][:job]
     assert       worker_span[:data][:'sidekiq-worker'][:'redis-url']
-    assert_equal false, worker_span[:data][:'sidekiq-worker'][:job_id].nil?
+    refute_nil   worker_span[:data][:'sidekiq-worker'][:job_id]
   end
 
   def assert_failed_worker_span(worker_span)
@@ -165,7 +165,7 @@ class SidekiqServerTest < Minitest::Test
     assert_equal 'important', worker_span[:data][:'sidekiq-worker'][:queue]
     assert_equal 'SidekiqJobTwo', worker_span[:data][:'sidekiq-worker'][:job]
     assert       worker_span[:data][:'sidekiq-worker'][:'redis-url']
-    assert_equal false, worker_span[:data][:'sidekiq-worker'][:job_id].nil?
+    refute_nil   worker_span[:data][:'sidekiq-worker'][:job_id]
 
     assert_equal true, worker_span[:data][:'sidekiq-worker'][:error]
     assert_equal 'Fail to execute the job', worker_span[:data][:log][:message]

--- a/test/secrets_test.rb
+++ b/test/secrets_test.rb
@@ -94,7 +94,7 @@ class SecretsTest < Minitest::Test
       "list"=>["stan"]
     }
 
-    assert_equal @subject.remove_from_query(nil, sample_config), nil
+    assert_nil @subject.remove_from_query(nil, sample_config)
   end
 
   private

--- a/test/tracing/tracer_test.rb
+++ b/test/tracing/tracer_test.rb
@@ -121,7 +121,7 @@ class TracerTest < Minitest::Test
     sdk_span = find_first_span_by_name(spans, :sub_block)
 
     assert_equal rack_span[:n], :rack
-    assert_equal rack_span[:p], nil
+    assert_nil rack_span[:p]
     assert_equal rack_span[:t], rack_span[:s]
     assert_equal rack_span[:data][:one], 1
 
@@ -151,7 +151,7 @@ class TracerTest < Minitest::Test
     assert_equal root_span[:data][:sdk][:name], :root_span
     assert_equal root_span[:data][:sdk][:type], :entry
     assert_equal root_span[:k], 1
-    assert_equal root_span[:p], nil
+    assert_nil root_span[:p]
     assert_equal root_span[:t], root_span[:s]
     assert_equal root_span[:data][:sdk][:custom][:tags][:one], 1
 


### PR DESCRIPTION
Fixes the following error message
````
DEPRECATED: Use assert_nil if expecting nil
from /workspace/ruby-sensor/test/secrets_test.rb:97.
This will fail in Minitest 6.
````