### PR TITLE
fix: Add missing gems for Ruby 3.3 and higher

### DIFF
--- a/instana.gemspec
+++ b/instana.gemspec
@@ -40,7 +40,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "appraisal"
   spec.add_development_dependency "fakefs"
 
+  spec.add_runtime_dependency('base64', '>= 0.1')
   spec.add_runtime_dependency('concurrent-ruby', '>= 1.1')
+  spec.add_runtime_dependency('csv', '>= 0.1')
   spec.add_runtime_dependency('sys-proctable', '>= 1.2.2')
   spec.add_runtime_dependency('oj', '>=3.0.11') unless RUBY_PLATFORM =~ /java/i
 end


### PR DESCRIPTION
Fixes the following 2 kinds of warnings:

````
lib/instana/backend/host_agent_lookup.rb:4: warning: csv was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add csv to your Gemfile or gemspec.
lib/instana/serverless.rb:4: warning: base64 was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add base64 to your Gemfile or gemspec.
````