### PR TITLE
fix: gem load for auto trace webhook

### DIFF
--- a/instana.gemspec
+++ b/instana.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "appraisal"
   spec.add_development_dependency "fakefs"
 
-  spec.add_runtime_dependency('base64', '>= 0.1')
+  spec.add_runtime_dependency('base64', '>= 0.1') if RUBY_VERSION < '3.3'
   spec.add_runtime_dependency('concurrent-ruby', '>= 1.1')
   spec.add_runtime_dependency('csv', '>= 0.1')
   spec.add_runtime_dependency('sys-proctable', '>= 1.2.2')


### PR DESCRIPTION
auto trace logic to load gems dynamically is failing in ruby 3.3.4 so adding this condition until we fix that.
