### PR TITLE
fix: failing rails tests

### DIFF
--- a/test/instrumentation/rails_active_record_test.rb
+++ b/test/instrumentation/rails_active_record_test.rb
@@ -17,7 +17,7 @@ class RailsActiveRecordTest < Minitest::Test
     ActiveRecord::Migration.suppress_messages do
       ActiveRecord::Migration.run(CreateBlocks, direction: :down)
     end
-    ActiveRecord::Base.remove_connection(@connection)
+    ActiveRecord::Base.remove_connection
   end
 
   def test_config_defaults


### PR DESCRIPTION
Deprecated name argument in remove_connection was causing issues. Initial method signature was **remove_connection(name = nil).** So removing the argument in this test file will fix the tests and should not have any repercussions on other areas.