### PR TITLE
fix: rubocop lint failures

### DIFF
--- a/lib/instana/instrumentation/active_record.rb
+++ b/lib/instana/instrumentation/active_record.rb
@@ -6,7 +6,7 @@ module Instana
     module ActiveRecord
       IGNORED_NAMES = %w[SCHEMA EXPLAIN CACHE].freeze
       IGNORED_SQL = %w[BEGIN COMMIT SET].freeze
-      SANITIZE_REGEXP = /('[\s\S][^']*'|\d*\.\d+|\d+|NULL)/i.freeze
+      SANITIZE_REGEXP = /('[\s\S][^']*'|\d*\.\d+|\d+|NULL)/i
 
       def log(sql, name = 'SQL', binds = [], *args, **kwargs, &block)
         call_payload = {

--- a/lib/instana/instrumentation/instrumented_request.rb
+++ b/lib/instana/instrumentation/instrumented_request.rb
@@ -9,8 +9,8 @@ require 'rack/request'
 
 module Instana
   class InstrumentedRequest < Rack::Request
-    W3C_TRACE_PARENT_FORMAT = /[0-9a-f][0-9a-e]-(?<trace>[0-9a-f]{32})-(?<parent>[0-9a-f]{16})-(?<flags>[0-9a-f]{2})/.freeze
-    INSTANA_TRACE_STATE = /in=(?<trace>[0-9a-f]+);(?<span>[0-9a-f]+)/.freeze
+    W3C_TRACE_PARENT_FORMAT = /[0-9a-f][0-9a-e]-(?<trace>[0-9a-f]{32})-(?<parent>[0-9a-f]{16})-(?<flags>[0-9a-f]{2})/
+    INSTANA_TRACE_STATE = /in=(?<trace>[0-9a-f]+);(?<span>[0-9a-f]+)/
 
     def skip_trace?
       # Honor X-Instana-L

--- a/lib/instana/instrumentation/sequel.rb
+++ b/lib/instana/instrumentation/sequel.rb
@@ -5,7 +5,7 @@ module Instana
     module Sequel
       IGNORED_SQL = %w[BEGIN COMMIT SET].freeze
       VERSION_SELECT_STATEMENT = "SELECT VERSION()".freeze
-      SANITIZE_REGEXP = /('[\s\S][^']*'|\d*\.\d+|\d+|NULL)/i.freeze
+      SANITIZE_REGEXP = /('[\s\S][^']*'|\d*\.\d+|\d+|NULL)/i
 
       def log_connection_yield(sql, conn, *args)
         call_payload = {


### PR DESCRIPTION
From ruby 3.0 regular expression objects are immutable. So no need to freeze them.