### PR TITLE
bug[429]: Unicorn remove the gem declaration if Instana disabled

### DIFF
--- a/lib/instana.rb
+++ b/lib/instana.rb
@@ -1,6 +1,6 @@
 # (c) Copyright IBM Corp. 2021
 # (c) Copyright Instana Inc. 2016
-if ENV.fetch('INSTANA_DISABLE', false)
+if ENV.fetch('INSTANA_DISABLE', false) && defined?(::Instana)
   Object.send(:remove_const, :Instana)
 end
 


### PR DESCRIPTION
unicorn worker was trying to delete the Instana constant twice. Hence adding check defined?