### PR TITLE
restrict concurrent-ruby to v-1.3.4 temporarily

### DIFF
--- a/gemfiles/rails_61.gemfile
+++ b/gemfiles/rails_61.gemfile
@@ -16,5 +16,6 @@ gem "rails", ">= 6.1", "< 7.0"
 gem "mysql2", "0.5.5"
 gem "pg"
 gem "sqlite3", "~> 1.4"
+gem "concurrent-ruby", "1.3.4"
 
 gemspec path: "../"

--- a/gemfiles/rails_70.gemfile
+++ b/gemfiles/rails_70.gemfile
@@ -13,5 +13,6 @@ gem "rails", "7.0.3"
 gem "mysql2", "0.5.5"
 gem "pg"
 gem "sqlite3", "~> 1.4"
+gem "concurrent-ruby", "1.3.4"
 
 gemspec path: "../"

--- a/instana.gemspec
+++ b/instana.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "fakefs"
 
   spec.add_runtime_dependency('base64', '>= 0.1')
-  spec.add_runtime_dependency('concurrent-ruby', '>= 1.1')
+  spec.add_runtime_dependency('concurrent-ruby', '1.3.4')
   spec.add_runtime_dependency('csv', '>= 0.1')
   spec.add_runtime_dependency('sys-proctable', '>= 1.2.2')
   spec.add_runtime_dependency('oj', '>=3.0.11') unless RUBY_PLATFORM =~ /java/i

--- a/instana.gemspec
+++ b/instana.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "fakefs"
 
   spec.add_runtime_dependency('base64', '>= 0.1')
-  spec.add_runtime_dependency('concurrent-ruby', '1.3.4')
+  spec.add_runtime_dependency('concurrent-ruby', '>= 1.1')
   spec.add_runtime_dependency('csv', '>= 0.1')
   spec.add_runtime_dependency('sys-proctable', '>= 1.2.2')
   spec.add_runtime_dependency('oj', '>=3.0.11') unless RUBY_PLATFORM =~ /java/i


### PR DESCRIPTION
circleci: restrict concurrent-ruby to v-1.3.4 temporarily for rails 6 and 7. 
This issue is because of the recent release of concurrent-ruby(1.3.5). This issue should be fixed in later releases of rails or concurrent-ruby. Until then we will be using concurrent-ruby(1.3.5) for rails 6 and 7 testing.