### PR TITLE
Migrate to alternative registries tekton

### DIFF
--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -6,26 +6,22 @@ spec:
   params:
   - name: revision
     type: string
-  - name: ruby_30_image_digest
-    type: string
-    # 3.0.7-bullseye
-    default: "ruby@sha256:dcb8a8a6ee981f949da505cb9f4f15cde696e7bcb088955bc1f92f23a4cd7a72"
   - name: ruby_31_image_digest
     type: string
-    # 3.1.4-bookworm
-    default: "ruby@sha256:ec69284bcbceb0a23ffc070ef2e0e8eb0fe495c20efbd51846b103338c3da1e4"
+    # ruby-3.1
+    default: "public.ecr.aws/docker/library/ruby:3.1"
   - name: ruby_32_image_digest
     type: string
-    # 3.2.3-bookworm
-    default: "ruby@sha256:007d2edd515f9cfc8c5c571486aca4fc4a25c903d004decee302961bb8c636ed"
+    # ruby-3.2
+    default: "public.ecr.aws/docker/library/ruby:3.2"
   - name: ruby_33_image_digest
     type: string
-    # 3.3.1-bookworm
-    default: "ruby@sha256:5cf0004738f54bd67e4c4316394208ca38a6726eda7a1b0586d95601aad86e5d"
+    # ruby-3.3
+    default: "public.ecr.aws/docker/library/ruby:3.3"
   - name: ruby_34_image_digest
     type: string
-    # 3.4.0-preview1-bookworm
-    default: "ruby@sha256:ac4f8074376743a56db23139238bd642a6249a25d4aaa250ca7e93332d11681c"
+    # ruby-3.4
+    default: "public.ecr.aws/docker/library/ruby:3.4"
   workspaces:
     - name: ruby-tracer-ci-pipeline-pvc
   tasks:
@@ -64,7 +60,6 @@ spec:
         params:
           - name: imageDigest
             value:
-            - $(params.ruby_30_image_digest)
             - $(params.ruby_31_image_digest)
             - $(params.ruby_32_image_digest)
             - $(params.ruby_33_image_digest)
@@ -80,47 +75,10 @@ spec:
       workspaces:
         - name: task-pvc
           workspace: ruby-tracer-ci-pipeline-pvc
-    - name: unittest-default-ruby-30
+    - name: unittest-default-ruby-31
       runAfter:
         - lint
         - core
-      matrix:
-        params:
-          - name: imageDigest
-            value:
-            - $(params.ruby_30_image_digest)
-          - name: gemfile
-            value:
-            - "./gemfiles/cuba_30.gemfile"
-            - "./gemfiles/cuba_40.gemfile"
-            - "./gemfiles/excon_079.gemfile"
-            - "./gemfiles/excon_0100.gemfile"
-            - "./gemfiles/excon_100.gemfile"
-            - "./gemfiles/graphql_10.gemfile"
-            - "./gemfiles/graphql_20.gemfile"
-            - "./gemfiles/grpc_10.gemfile"
-            - "./gemfiles/net_http_01.gemfile"
-            - "./gemfiles/rack_20.gemfile"
-            - "./gemfiles/rack_30.gemfile"
-            - "./gemfiles/rest_client_20.gemfile"
-            - "./gemfiles/roda_20.gemfile"
-            - "./gemfiles/roda_30.gemfile"
-            - "./gemfiles/sinatra_22.gemfile"
-            - "./gemfiles/sinatra_30.gemfile"
-            - "./gemfiles/sinatra_40.gemfile"
-            - "./gemfiles/shoryuken_50.gemfile"
-            - "./gemfiles/shoryuken_60.gemfile"
-          - name: configuration
-            value:
-            - "libraries"
-      taskRef:
-        name: ruby-tracer-unittest-default-libraries-task
-      workspaces:
-        - name: task-pvc
-          workspace: ruby-tracer-ci-pipeline-pvc
-    - name: unittest-default-ruby-31
-      runAfter:
-        - unittest-default-ruby-30
       matrix:
         params:
           - name: imageDigest
@@ -273,7 +231,6 @@ spec:
         params:
           - name: imageDigest
             value:
-            - $(params.ruby_30_image_digest)
             - $(params.ruby_31_image_digest)
             - $(params.ruby_32_image_digest)
             - $(params.ruby_33_image_digest)
@@ -294,7 +251,6 @@ spec:
         params:
           - name: imageDigest
             value:
-            - $(params.ruby_30_image_digest)
             - $(params.ruby_31_image_digest)
             - $(params.ruby_32_image_digest)
             - $(params.ruby_33_image_digest)
@@ -316,7 +272,6 @@ spec:
         params:
           - name: imageDigest
             value:
-            - $(params.ruby_30_image_digest)
             - $(params.ruby_31_image_digest)
             - $(params.ruby_32_image_digest)
             - $(params.ruby_33_image_digest)
@@ -330,14 +285,13 @@ spec:
       workspaces:
         - name: task-pvc
           workspace: ruby-tracer-ci-pipeline-pvc
-    - name: unittest-redis-ruby-30-31
+    - name: unittest-redis-ruby-31
       runAfter:
         - unittest-aws
       matrix:
         params:
           - name: imageDigest
             value:
-            - $(params.ruby_30_image_digest)
             - $(params.ruby_31_image_digest)
           - name: gemfile
             value:
@@ -358,7 +312,7 @@ spec:
           workspace: ruby-tracer-ci-pipeline-pvc
     - name: unittest-redis-ruby-32-33
       runAfter:
-        - unittest-redis-ruby-30-31
+        - unittest-redis-ruby-31
       matrix:
         params:
           - name: imageDigest
@@ -414,7 +368,6 @@ spec:
         params:
           - name: imageDigest
             value:
-            - $(params.ruby_30_image_digest)
             - $(params.ruby_31_image_digest)
             - $(params.ruby_32_image_digest)
             - $(params.ruby_33_image_digest)
@@ -436,7 +389,6 @@ spec:
         params:
           - name: imageDigest
             value:
-            - $(params.ruby_30_image_digest)
             - $(params.ruby_31_image_digest)
             - $(params.ruby_32_image_digest)
             - $(params.ruby_33_image_digest)
@@ -458,7 +410,6 @@ spec:
         params:
           - name: imageDigest
             value:
-            - $(params.ruby_30_image_digest)
             - $(params.ruby_31_image_digest)
             - $(params.ruby_32_image_digest)
             - $(params.ruby_33_image_digest)
@@ -480,7 +431,6 @@ spec:
         params:
           - name: imageDigest
             value:
-            - $(params.ruby_30_image_digest)
             - $(params.ruby_31_image_digest)
             - $(params.ruby_32_image_digest)
             - $(params.ruby_33_image_digest)
@@ -502,7 +452,6 @@ spec:
         params:
           - name: imageDigest
             value:
-            - $(params.ruby_30_image_digest)
             - $(params.ruby_31_image_digest)
             - $(params.ruby_32_image_digest)
             - $(params.ruby_33_image_digest)

--- a/.tekton/prepuller-restart-service-account.yaml
+++ b/.tekton/prepuller-restart-service-account.yaml
@@ -1,0 +1,31 @@
+---
+# Service account which will be use to reset the daemonset,
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: prepuller-restart
+---
+# allow getting status and patching only the one daemonset you want
+# to restart
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prepuller-restart
+rules:
+  - apiGroups: ["apps", "extensions"]
+    resources: ["daemonsets"]
+    resourceNames: ["ruby-tracer-prepuller"]
+    verbs: ["get", "patch"]
+---
+# bind the role to the service account
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prepuller-restart
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prepuller-restart
+subjects:
+  - kind: ServiceAccount
+    name: prepuller-restart

--- a/.tekton/ruby-tracer-prepuller-cronjob.yaml
+++ b/.tekton/ruby-tracer-prepuller-cronjob.yaml
@@ -1,0 +1,20 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: deploy-daemonset
+spec:
+  schedule: "0 0 * * Mon-Fri"  # Run every weekday at 12AM
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: prepuller-restart
+          containers:
+            - name: kubectl
+              image: bitnami/kubectl
+              command:
+                - 'kubectl'
+                - 'rollout'
+                - 'restart'
+                - 'daemonset/ruby-tracer-prepuller'
+          restartPolicy: OnFailure

--- a/.tekton/ruby-tracer-prepuller.yaml
+++ b/.tekton/ruby-tracer-prepuller.yaml
@@ -14,65 +14,66 @@ spec:
       # Configure an init container for each image you want to pull
       initContainers:
         - name: prepuller-git
-          # alpine/git:2.43.0
-          image: alpine/git@sha256:6ff4de047dcc8f0c7d75d2efff63fbc189e87d2f458305f2cc8f165ff83309cf
+          # alpine/git:latest
+          image: public.ecr.aws/docker/library/alpine:latest
           command: ["sh", "-c", "'true'"]
         - name: prepuller-dynamodb
           # amazon/dynamodb-local:2.3.0
-          image: amazon/dynamodb-local@sha256:0e42a967205042118277be031a59f7aa035c2f90b1695b1b3250d0ce03a7c8f0
+          image: public.ecr.aws/aws-dynamodb-local/aws-dynamodb-local:2.3.0
           command: ["sh", "-c", "'true'"]
         - name: prepuller-s3
-          # minio/minio:RELEASE.2024-03-07T00-43-48Z
-          image: minio/minio@sha256:9224601c529f424e5efac79f95606f0c7e1fe234f3f45344a49deaccd66d5bf5
+          # minio/minio
+          image: quay.io/minio/minio
           command: ["sh", "-c", "'true'"]
         - name: prepuller-sns
           # s12v/sns:latest
-          image: s12v/sns@sha256:a80f1cd6318d22419cab38650ee6824f72cc2dc902d2b38e4f997d0530fe4e07
+          image: public.ecr.aws/redbox-public/s12v/sns:latest
           command: ["sh", "-c", "'true'"]
         - name: prepuller-sqs
-          # softwaremill/elasticmq-native:1.5.7
-          image: softwaremill/elasticmq-native@sha256:9183333a9ea4666686c37dc83a2b1f8cee9c15ffd161a219a131e171039f1ac3
+          # sprig/elasticmq-native
+          image: public.ecr.aws/sprig/elasticmq-native
           command: ["sh", "-c", "'true'"]
         - name: prepuller-memcached
           # memcached:1.6.24-bookworm
-          image: memcached@sha256:b2b562323463b6cda240a148fb2a5b7ea86e8017a8509e10a3c7f1681f259193
+          image: public.ecr.aws/docker/library/memcached:1.6.24-bookworm
           command: ["sh", "-c", "'true'"]
         - name: prepuller-redis
           # redis:7.2.4-bookworm
-          image: redis@sha256:fe98b2d39d462d06a7360e2860dd6ceff930745e3731eccb3c1406dd0dd7f744
+          image: public.ecr.aws/docker/library/redis:7.2.4-bookworm
           command: ["sh", "-c", "'true'"]
         - name: prepuller-mongo
-          # mongo:5.0.25-focal
-          image: mongo@sha256:d1b8a7b77424347397653ab8ff500c66b1e9979b4cebf826951d37b0d3966721
+          # mongo:5-focal
+          image: public.ecr.aws/docker/library/mongo:5-focal
           command: ["sh", "-c", "'true'"]
+          imagePullPolicy: Always
         - name: prepuller-mariadb
           # mariadb:11.3.2
-          image: mariadb@sha256:851f05fe1e4cb290442c1b12b7108436a33fd8f6a733d4989950322d06d45c65
+          image: public.ecr.aws/docker/library/mariadb:11.3.2
           command: ["sh", "-c", "'true'"]
         - name: prepuller-postgres
           # postgres:16.2-bookworm
-          image: postgres@sha256:6b841c8f6a819884207402f1209a8116844365df15fca8cf556fc54a24c70800
-          command: ["sh", "-c", "'true'"]
-        - name: prepuller-30
-          # 3.0.6-bullseye
-          image: ruby@sha256:3166618469ad8a3190d80f43b322818fafb4bfac0b4882255eee3346af2a0a35
+          image: public.ecr.aws/docker/library/postgres:16.2-bookworm
           command: ["sh", "-c", "'true'"]
         - name: prepuller-31
-          # 3.1.4-bookworm
-          image: ruby@sha256:ec69284bcbceb0a23ffc070ef2e0e8eb0fe495c20efbd51846b103338c3da1e4
+          # ruby-3.1
+          image: public.ecr.aws/docker/library/ruby:3.1
           command: ["sh", "-c", "'true'"]
+          imagePullPolicy: Always
         - name: prepuller-32
-          # 3.2.3-bookworm
-          image: ruby@sha256:007d2edd515f9cfc8c5c571486aca4fc4a25c903d004decee302961bb8c636ed
+          # ruby-3.2
+          image: public.ecr.aws/docker/library/ruby:3.2
           command: ["sh", "-c", "'true'"]
+          imagePullPolicy: Always
         - name: prepuller-33
-          # 3.3.1-bookworm
-          image: ruby@sha256:5cf0004738f54bd67e4c4316394208ca38a6726eda7a1b0586d95601aad86e5d
+          # ruby-3.3
+          image: public.ecr.aws/docker/library/ruby:3.3
           command: ["sh", "-c", "'true'"]
+          imagePullPolicy: Always
         - name: prepuller-34
-          # 3.4.0-preview1-bookworm
-          image: ruby@sha256:2690af2a931469abe513b22a083b5ae0b56d4feffc0d3496eb6378723ab203e7
+          # ruby-3.4
+          image: public.ecr.aws/docker/library/ruby:3.4
           command: ["sh", "-c", "'true'"]
+          imagePullPolicy: Always
       # Use the pause container to ensure the Pod goes into a `Running` phase
       # but doesn't take up resource on the cluster
       containers:

--- a/.tekton/task.yaml
+++ b/.tekton/task.yaml
@@ -12,10 +12,12 @@ spec:
       mountPath: /workspace
   steps:
     - name: clone
-      # alpine/git:2.43.0
-      image: alpine/git@sha256:6ff4de047dcc8f0c7d75d2efff63fbc189e87d2f458305f2cc8f165ff83309cf
+      # alpine/git:latest
+      image: public.ecr.aws/docker/library/alpine:latest
       script: |
         #!/bin/sh
+        echo "Installing git"
+        apk fix && apk --no-cache --update add git gpg less openssh patch
         echo "Cloning repo"
         cd /workspace && git clone --depth 1 -b $(params.revision) https://github.com/instana/ruby-sensor
         ls -lah /workspace
@@ -56,7 +58,7 @@ spec:
   # MySQL (compatible Mariadb)
   - name: mariadb
     # mariadb:11.3.2
-    image: mariadb@sha256:851f05fe1e4cb290442c1b12b7108436a33fd8f6a733d4989950322d06d45c65
+    image: public.ecr.aws/docker/library/mariadb:11.3.2
     startupProbe:
       initialDelaySeconds: 10
       tcpSocket:
@@ -96,7 +98,7 @@ spec:
   sidecars:
   - name: postgres
     # postgres:16.2-bookworm
-    image: postgres@sha256:6b841c8f6a819884207402f1209a8116844365df15fca8cf556fc54a24c70800
+    image: public.ecr.aws/docker/library/postgres:16.2-bookworm
     startupProbe:
       initialDelaySeconds: 10
       tcpSocket:
@@ -139,15 +141,15 @@ spec:
   # Amazon DynamoDB
   - name: dynamodb
     # amazon/dynamodb-local:2.3.0
-    image: amazon/dynamodb-local@sha256:0e42a967205042118277be031a59f7aa035c2f90b1695b1b3250d0ce03a7c8f0
+    image: public.ecr.aws/aws-dynamodb-local/aws-dynamodb-local:2.3.0
     startupProbe:
       tcpSocket:
         port: 8000
       initialDelaySeconds: 10
   # Amazon S3
   - name: s3
-    # minio/minio:RELEASE.2024-03-07T00-43-48Z
-    image: minio/minio@sha256:9224601c529f424e5efac79f95606f0c7e1fe234f3f45344a49deaccd66d5bf5
+    # minio/minio:latest
+    image: quay.io/minio/minio
     command:
       - /usr/bin/minio
       - server
@@ -155,11 +157,11 @@ spec:
   # Amazon SNS
   - name: sns
     # s12v/sns:latest
-    image: s12v/sns@sha256:a80f1cd6318d22419cab38650ee6824f72cc2dc902d2b38e4f997d0530fe4e07
+    image: public.ecr.aws/redbox-public/s12v/sns:latest
   # Amazon SQS
   - name: sqs
     # softwaremill/elasticmq-native:1.5.7
-    image: softwaremill/elasticmq-native@sha256:9183333a9ea4666686c37dc83a2b1f8cee9c15ffd161a219a131e171039f1ac3
+    image: public.ecr.aws/sprig/elasticmq-native
   params:
   - name: imageDigest
     type: string
@@ -189,7 +191,7 @@ spec:
   # Redis
   - name: redis
     # redis:7.2.4-bookworm
-    image: redis@sha256:fe98b2d39d462d06a7360e2860dd6ceff930745e3731eccb3c1406dd0dd7f744
+    image: public.ecr.aws/docker/library/redis:7.2.4-bookworm
     startupProbe:
       initialDelaySeconds: 10
       tcpSocket:
@@ -223,7 +225,7 @@ spec:
   # Memcached
   - name: memcached
     # memcached:1.6.24-bookworm
-    image: memcached@sha256:b2b562323463b6cda240a148fb2a5b7ea86e8017a8509e10a3c7f1681f259193
+    image: public.ecr.aws/docker/library/memcached:1.6.24-bookworm
     startupProbe:
       tcpSocket:
         port: 11211
@@ -256,7 +258,7 @@ spec:
   sidecars:
   - name: mongo
     # mongo:5.0.25-focal
-    image: mongo@sha256:d1b8a7b77424347397653ab8ff500c66b1e9979b4cebf826951d37b0d3966721
+    image: public.ecr.aws/docker/library/mongo:5-focal
     startupProbe:
       initialDelaySeconds: 10
       tcpSocket:
@@ -344,7 +346,7 @@ spec:
   # MySQL (compatible Mariadb)
   - name: mariadb
     # mariadb:11.3.2
-    image: mariadb@sha256:851f05fe1e4cb290442c1b12b7108436a33fd8f6a733d4989950322d06d45c65
+    image: public.ecr.aws/docker/library/mariadb:11.3.2
     startupProbe:
       initialDelaySeconds: 10
       tcpSocket:
@@ -386,8 +388,8 @@ spec:
       mountPath: /workspace
   steps:
     - name: generate-currency-report
-      # 3.10.13-bookworm
-      image: python@sha256:c970ff53939772f47b0672e380328afb50d8fd1c0568ed4f82c22effc54244fc
+      # 3.10-bookworm
+      image: public.ecr.aws/docker/library/python:3.10-bookworm
       script: |
         #!/usr/bin/env bash
 
@@ -418,7 +420,7 @@ spec:
   steps:
     - name: upload-currency-report
       # alpine/git:2.43.0
-      image: alpine/git@sha256:6ff4de047dcc8f0c7d75d2efff63fbc189e87d2f458305f2cc8f165ff83309cf
+      image: public.ecr.aws/docker/library/alpine:latest
       env:
         - name: GH_ENTERPRISE_TOKEN
           valueFrom:


### PR DESCRIPTION
Migrate the image registries from docker to aws.
Also use the latest minor versions of ruby by changing the tag to 3.X. Which will always be pointing to latest monor version of ruby. This would pose a challenge when resolving image tags. So have created a prepuller daemon which restarts everyday and makes sure that the latest SHA for 3.x tag is being pulled.