### PR TITLE
chore: fix gem publish job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,7 +176,7 @@ commands:
           command: |
             mkdir -p ~/.gem
             echo -e "---\r\n:rubygems_api_key: $RUBYGEMS_API_KEY" > ~/.gem/credentials
-            chmod 0600 /home/circleci/.gem/credentials
+            chmod 0600 ~/.gem/credentials
       - run:
           name: Publish Gem
           command: |


### PR DESCRIPTION
The publish workflow is failing because of the directory miss match. https://app.circleci.com/pipelines/github/instana/ruby-sensor/1906/workflows/9e5ee69a-374c-496b-aed8-d715134dfc97/jobs/278539