### PR TITLE
fix: no method error caused when there is a missmatch in context object

### DIFF
--- a/lib/instana/trace/tracer_provider.rb
+++ b/lib/instana/trace/tracer_provider.rb
@@ -135,7 +135,7 @@ module Instana
       def internal_start_span(name, kind, attributes, links, start_timestamp, parent_context, instrumentation_scope) # rubocop:disable Metrics/ParameterLists
         parent_span = OpenTelemetry::Trace.current_span(parent_context)
         parent_span_context = parent_span.context if parent_span
-        if parent_span_context&.valid?
+        if parent_span_context.respond_to?(:valid?) && parent_span_context.valid?
           parent_span_id = parent_span_context.span_id
           trace_id = parent_span_context.trace_id
           span_id = @id_generator.generate_span_id


### PR DESCRIPTION
Fix NoMethodError for undefined valid? method on OpenTelemetry::Context
Problem
The application was crashing with an uncaught NoMethodError during span creation in the Rack middleware:

```
NoMethodError: undefined method 'valid?' for an instance of OpenTelemetry::Context

    if parent_span_context&.valid?
                          ^^^^^^^^
from instana/trace/tracer_provider.rb:138:in 'internal_start_span'
```


This error occurred in the request handling pipeline, blocking span creation and potentially causing application failures in production environments.

Root Cause
The code was calling [valid?()](vscode-webview://01akijocqn6o1emlp4fdt4g6vt051b4774p45nobne1qb74aoj3e/ruby-sensor/lib/instana/trace/tracer_provider.rb:138) directly on parent_span_context without first checking if the object responds to this method. In certain edge cases, the parent_span_context object may not have the valid? method available, leading to the NoMethodError.

Solution
Added a defensive guard using [respond_to?(:valid?)](vscode-webview://01akijocqn6o1emlp4fdt4g6vt051b4774p45nobne1qb74aoj3e/ruby-sensor/lib/instana/trace/tracer_provider.rb:138) before calling the valid? method:

Before:

`if parent_span_context&.valid?`

After:

`if parent_span_context&.respond_to?(:valid?) && parent_span_context.valid?`

This ensures the method exists on the object before attempting to call it, preventing the NoMethodError from being raised.

Impact
Prevents application crashes during span creation in the Rack instrumentation layer
Maintains backward compatibility with different OpenTelemetry context implementations
Graceful degradation when encountering unexpected context objects
Testing Notes
Since the exact conditions to reproduce this error could not be reliably replicated, this defensive programming approach provides the safest fix to prevent crashes in client applications while maintaining existing functionality.