### PR TITLE
feat(otl-exporter): add converters to all instrumentation

### DIFF
--- a/lib/instana/exporter/otlp/aws_converter.rb
+++ b/lib/instana/exporter/otlp/aws_converter.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+# (c) Copyright IBM Corp. 2026
+
+require_relative 'base_converter'
+require 'opentelemetry/semconv/incubating/messaging'
+require 'opentelemetry/semconv/db'
+require 'opentelemetry/semconv/incubating/db'
+
+module Instana
+  module Exporter
+    module Otlp
+      # Converter for AWS SDK spans (SQS, SNS, DynamoDB) to OTLP format
+      class AwsConverter < BaseConverter
+        def convert_attributes
+          attributes = {}
+
+          # AWS SQS
+          sqs_data = span[:data]&.[](:sqs)
+          if sqs_data
+            add_attribute(attributes, OpenTelemetry::SemConv::Incubating::MESSAGING::MESSAGING_SYSTEM, 'aws_sqs')
+            add_attribute(attributes, OpenTelemetry::SemConv::Incubating::MESSAGING::MESSAGING_DESTINATION_NAME, sqs_data[:queue])
+            add_attribute(attributes, 'messaging.aws.sqs.message_group_id', sqs_data[:group])
+            add_attribute(attributes, OpenTelemetry::SemConv::Incubating::MESSAGING::MESSAGING_BATCH_MESSAGE_COUNT, sqs_data[:size])
+
+            operation = case sqs_data[:type]
+                        when /^send/, /^single\.sync/ then 'send'
+                        when /^delete/ then 'process'
+                        when /^create/, /^get/ then 'create'
+                        else 'send'
+                        end
+            add_attribute(attributes, OpenTelemetry::SemConv::Incubating::MESSAGING::MESSAGING_OPERATION_TYPE, operation)
+          end
+
+          # AWS SNS
+          sns_data = span[:data]&.[](:sns)
+          if sns_data
+            add_attribute(attributes, OpenTelemetry::SemConv::Incubating::MESSAGING::MESSAGING_SYSTEM, 'aws_sns')
+            add_attribute(attributes, OpenTelemetry::SemConv::Incubating::MESSAGING::MESSAGING_DESTINATION_NAME, sns_data[:topic])
+            add_attribute(attributes, 'messaging.aws.sns.target_arn', sns_data[:target])
+            add_attribute(attributes, 'messaging.aws.sns.phone_number', sns_data[:phone])
+            add_attribute(attributes, 'messaging.aws.sns.subject', sns_data[:subject])
+            add_attribute(attributes, OpenTelemetry::SemConv::Incubating::MESSAGING::MESSAGING_OPERATION_TYPE, 'send')
+          end
+
+          # AWS DynamoDB
+          dynamodb_data = span[:data]&.[](:dynamodb)
+          if dynamodb_data
+            add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_SYSTEM_NAME, 'dynamodb')
+            add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_OPERATION_NAME, dynamodb_data[:op])
+            add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_NAMESPACE, dynamodb_data[:table])
+            add_attribute(attributes, 'aws.dynamodb.table_name', dynamodb_data[:table])
+          end
+
+          # AWS S3
+          s3_data = span[:data]&.[](:s3)
+          if s3_data
+            add_attribute(attributes, 'aws.service', 's3')
+            add_attribute(attributes, 'aws.s3.bucket', s3_data[:bucket])
+            add_attribute(attributes, 'aws.s3.key', s3_data[:key])
+            add_attribute(attributes, 'aws.s3.operation', s3_data[:op])
+          end
+
+          # AWS Lambda
+          lambda_data = span[:data]&.[](:aws)&.[](:lambda)&.[](:invoke)
+          if lambda_data
+            add_attribute(attributes, 'aws.service', 'lambda')
+            add_attribute(attributes, 'aws.lambda.function_name', lambda_data[:function])
+            add_attribute(attributes, 'aws.lambda.invocation_type', lambda_data[:type])
+            add_attribute(attributes, 'faas.invoked_name', lambda_data[:function])
+          end
+
+          attributes
+        end
+      end
+    end
+  end
+end

--- a/lib/instana/exporter/otlp/background_job_converter.rb
+++ b/lib/instana/exporter/otlp/background_job_converter.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+# (c) Copyright IBM Corp. 2026
+
+require_relative 'base_converter'
+require 'opentelemetry/semconv/incubating/messaging'
+require 'opentelemetry/semconv/server'
+
+module Instana
+  module Exporter
+    module Otlp
+      class BackgroundJobConverter < BaseConverter
+        def convert_attributes
+          attributes = {}
+
+          case span[:n].to_s
+          when 'sidekiq-client'
+            convert_job_attributes(attributes, span[:'sidekiq-client'] || span[:data]&.[](:'sidekiq-client'), 'sidekiq', 'publish')
+          when 'sidekiq-worker'
+            convert_job_attributes(attributes, span[:'sidekiq-worker'] || span[:data]&.[](:'sidekiq-worker'), 'sidekiq', 'process')
+          when 'resque-client'
+            convert_job_attributes(attributes, span[:'resque-client'] || span[:data]&.[](:'resque-client'), 'resque', 'publish')
+          when 'resque-worker'
+            convert_job_attributes(attributes, span[:'resque-worker'] || span[:data]&.[](:'resque-worker'), 'resque', 'process')
+          end
+
+          attributes
+        end
+
+        private
+
+        def convert_job_attributes(attributes, data, system, operation)
+          return unless data
+
+          add_attribute(attributes, OpenTelemetry::SemConv::Incubating::MESSAGING::MESSAGING_SYSTEM, system)
+          add_attribute(attributes, OpenTelemetry::SemConv::Incubating::MESSAGING::MESSAGING_DESTINATION_NAME, data[:queue] || data['queue'])
+          add_attribute(attributes, OpenTelemetry::SemConv::Incubating::MESSAGING::MESSAGING_OPERATION, operation)
+          add_attribute(attributes, OpenTelemetry::SemConv::Incubating::MESSAGING::MESSAGING_MESSAGE_ID, data[:job_id] || data['job_id'])
+          add_attribute(attributes, OpenTelemetry::SemConv::Incubating::MESSAGING::MESSAGING_CONSUMER_GROUP_NAME, data[:job] || data['job'])
+          add_attribute(attributes, OpenTelemetry::SemConv::SERVER::SERVER_ADDRESS, extract_host(data[:'redis-url'] || data['redis-url']))
+          add_attribute(attributes, OpenTelemetry::SemConv::SERVER::SERVER_PORT, extract_port(data[:'redis-url'] || data['redis-url']))
+        end
+
+        def extract_host(connection)
+          return nil unless connection
+
+          connection.to_s.split(':').first
+        end
+
+        def extract_port(connection)
+          return nil unless connection
+
+          port = connection.to_s.split(':').last
+          port.to_i if port =~ /^\d+$/
+        end
+      end
+    end
+  end
+end

--- a/lib/instana/exporter/otlp/converter_factory.rb
+++ b/lib/instana/exporter/otlp/converter_factory.rb
@@ -124,10 +124,10 @@ module Instana
             span[:n]&.match?(/grpc|rpc/i)
           end
 
-          # Check if span is a custom span
-          # Instana native spans always have a name, so we only check the name
+          # Check if span is an Instana SDK custom span
           def custom_span?(span)
-            span[:n]&.match?(/custom|sdk/i)
+            span[:n]&.match?(/custom|sdk/i) ||
+              span[:data]&.dig(:sdk, :type)&.to_s == 'custom'
           end
         end
       end

--- a/lib/instana/exporter/otlp/converter_factory.rb
+++ b/lib/instana/exporter/otlp/converter_factory.rb
@@ -6,7 +6,11 @@ require_relative 'base_converter'
 require_relative 'http_converter'
 require_relative 'database_converter'
 require_relative 'messaging_converter'
+require_relative 'background_job_converter'
+require_relative 'aws_converter'
 require_relative 'rpc_converter'
+require_relative 'rails_converter'
+require_relative 'graphql_converter'
 require_relative 'custom_converter'
 require_relative 'internal_converter'
 require_relative '../../trace/span_kind'
@@ -22,7 +26,11 @@ module Instana
           http: 'http',
           database: 'database',
           messaging: 'messaging',
+          background_job: 'background_job',
+          aws: 'aws',
           rpc: 'rpc',
+          rails: 'rails',
+          graphql: 'graphql',
           internal: 'internal',
           custom: 'custom'
         }.freeze
@@ -46,7 +54,11 @@ module Instana
           def determine_span_type(span)
             return SPAN_TYPES[:http] if http_span?(span)
             return SPAN_TYPES[:database] if database_span?(span)
+            return SPAN_TYPES[:aws] if aws_span?(span)
+            return SPAN_TYPES[:background_job] if background_job_span?(span)
             return SPAN_TYPES[:messaging] if messaging_span?(span)
+            return SPAN_TYPES[:rails] if rails_span?(span)
+            return SPAN_TYPES[:graphql] if graphql_span?(span)
             return SPAN_TYPES[:rpc] if rpc_span?(span)
             return SPAN_TYPES[:custom] if custom_span?(span)
 
@@ -57,7 +69,8 @@ module Instana
           # @param span_type [String] The type of span
           # @return [Class] The converter class
           def get_converter_class(span_type)
-            class_name = "#{span_type.capitalize}Converter"
+            # Convert snake_case to CamelCase (e.g., 'background_job' -> 'BackgroundJob')
+            class_name = "#{span_type.split('_').map(&:capitalize).join}Converter"
 
             begin
               const_get("Instana::Exporter::Otlp::#{class_name}")
@@ -79,10 +92,30 @@ module Instana
             span[:n]&.match?(/sql|database|query|activerecord|sequel|mongo|redis|dalli/i)
           end
 
+          # Check if span is an AWS span
+          # Note: SQS and SNS are handled by messaging_span? since they're messaging services
+          def aws_span?(span)
+            span[:n]&.match?(/dynamodb|s3|aws\.lambda/i)
+          end
+
           # Check if span is a messaging span
-          # Instana native spans always have a name, so we only check the name
           def messaging_span?(span)
-            span[:n]&.match?(/kafka|rabbitmq|sqs|sns|message|bunny|shoryuken/i)
+            span[:n]&.match?(/sqs|sns|kafka|rabbitmq|message|bunny|shoryuken/i)
+          end
+
+          # Check if span is a background job span
+          def background_job_span?(span)
+            span[:n]&.match?(/sidekiq-(client|worker)|resque-(client|worker)/i)
+          end
+
+          # Check if span is a Rails span
+          def rails_span?(span)
+            span[:n]&.match?(/actioncontroller|actionview|actionmailer|render|mail\.actionmailer/i)
+          end
+
+          # Check if span is a GraphQL span
+          def graphql_span?(span)
+            span[:n]&.match?(/graphql/i)
           end
 
           # Check if span is an RPC span

--- a/lib/instana/exporter/otlp/custom_converter.rb
+++ b/lib/instana/exporter/otlp/custom_converter.rb
@@ -5,12 +5,25 @@
 module Instana
   module Exporter
     module Otlp
-      # Stub converter for custom spans to OTLP format
-      # This is a placeholder implementation for custom application-specific spans
-      # TODO: Implement full custom span conversion logic
+      # Converter for Instana SDK custom spans to OTLP format
       class CustomConverter < BaseConverter
-        # Convert custom span to OTLP format
-        # @return [Hash] Converted custom span data in OTLP format
+        def convert_attributes
+          attributes = {}
+          sdk_data = span[:data]&.[](:sdk) || {}
+
+          # Add standard Instana attributes
+          add_attribute(attributes, 'instana.span.type', 'custom')
+          add_attribute(attributes, 'instana.sdk.name', sdk_data[:name] || span[:n])
+          add_attribute(attributes, 'instana.sdk.type', sdk_data[:type])
+
+          # Add tags directly
+          tags = sdk_data.dig(:custom, :tags) || {}
+          tags.each do |key, value|
+            attributes[key] = value
+          end
+
+          attributes
+        end
       end
     end
   end

--- a/lib/instana/exporter/otlp/database_converter.rb
+++ b/lib/instana/exporter/otlp/database_converter.rb
@@ -4,7 +4,6 @@
 
 require_relative 'base_converter'
 require 'opentelemetry/semconv/db'
-require 'opentelemetry/semconv/db'
 require 'opentelemetry/semconv/server'
 
 module Instana

--- a/lib/instana/exporter/otlp/database_converter.rb
+++ b/lib/instana/exporter/otlp/database_converter.rb
@@ -4,6 +4,7 @@
 
 require_relative 'base_converter'
 require 'opentelemetry/semconv/db'
+require 'opentelemetry/semconv/db'
 require 'opentelemetry/semconv/server'
 
 module Instana
@@ -17,27 +18,27 @@ module Instana
           # ActiveRecord
           ar_data = span[:data]&.[](:activerecord)
           if ar_data
-            add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_SYSTEM, ar_data[:adapter])
+            add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_SYSTEM_NAME, ar_data[:adapter])
             add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_NAMESPACE, ar_data[:db])
             add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_QUERY_TEXT, ar_data[:sql])
-            add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_USER, ar_data[:username])
+            add_attribute(attributes, OpenTelemetry::SemConv::Incubating::DB::DB_USER, ar_data[:username])
             add_attribute(attributes, OpenTelemetry::SemConv::SERVER::SERVER_ADDRESS, ar_data[:host])
           end
 
           # Sequel
           seq_data = span[:data]&.[](:sequel)
           if seq_data
-            add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_SYSTEM, seq_data[:adapter])
+            add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_SYSTEM_NAME, seq_data[:adapter])
             add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_NAMESPACE, seq_data[:db])
             add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_QUERY_TEXT, seq_data[:sql])
-            add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_USER, seq_data[:username])
+            add_attribute(attributes, OpenTelemetry::SemConv::Incubating::DB::DB_USER, seq_data[:username])
             add_attribute(attributes, OpenTelemetry::SemConv::SERVER::SERVER_ADDRESS, seq_data[:host])
           end
 
           # Redis
           redis_data = span[:data]&.[](:redis)
           if redis_data
-            add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_SYSTEM, 'redis')
+            add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_SYSTEM_NAME, 'redis')
             add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_QUERY_TEXT, redis_data[:command])
             add_attribute(attributes, 'db.redis.database_index', redis_data[:db])
             add_attribute(attributes, OpenTelemetry::SemConv::SERVER::SERVER_ADDRESS, extract_host(redis_data[:connection]))
@@ -47,7 +48,7 @@ module Instana
           # Memcache (Dalli)
           mc_data = span[:data]&.[](:memcache)
           if mc_data
-            add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_SYSTEM, 'memcached')
+            add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_SYSTEM_NAME, 'memcached')
             add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_OPERATION_NAME, mc_data[:command])
             add_attribute(attributes, 'db.memcached.key', mc_data[:key])
             add_attribute(attributes, 'db.memcached.keys', mc_data[:keys])
@@ -59,7 +60,7 @@ module Instana
           # MongoDB
           mongo_data = span[:data]&.[](:mongo)
           if mongo_data
-            add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_SYSTEM, 'mongodb')
+            add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_SYSTEM_NAME, 'mongodb')
             add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_NAMESPACE, mongo_data[:namespace])
             add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_OPERATION_NAME, mongo_data[:command])
             add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_QUERY_TEXT, mongo_data[:json])

--- a/lib/instana/exporter/otlp/database_converter.rb
+++ b/lib/instana/exporter/otlp/database_converter.rb
@@ -2,15 +2,88 @@
 
 # (c) Copyright IBM Corp. 2026
 
+require_relative 'base_converter'
+require 'opentelemetry/semconv/db'
+require 'opentelemetry/semconv/server'
+
 module Instana
   module Exporter
     module Otlp
       # Converter for database spans to OTLP format
-      # Handles conversion of database-related spans with specific attributes
-      # NOTE: This converter is a placeholder for future implementation
       class DatabaseConverter < BaseConverter
-        # Convert database span to OTLP format
-        # @return [Hash] Converted database span data in OTLP format
+        def convert_attributes
+          attributes = {}
+          Instana.logger.info("inside database converter")
+          # ActiveRecord
+          ar_data = span[:data]&.[](:activerecord)
+          if ar_data
+            add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_SYSTEM, ar_data[:adapter])
+            add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_NAMESPACE, ar_data[:db])
+            add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_QUERY_TEXT, ar_data[:sql])
+            add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_USER, ar_data[:username])
+            add_attribute(attributes, OpenTelemetry::SemConv::SERVER::SERVER_ADDRESS, ar_data[:host])
+          end
+
+          # Sequel
+          seq_data = span[:data]&.[](:sequel)
+          if seq_data
+            add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_SYSTEM, seq_data[:adapter])
+            add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_NAMESPACE, seq_data[:db])
+            add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_QUERY_TEXT, seq_data[:sql])
+            add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_USER, seq_data[:username])
+            add_attribute(attributes, OpenTelemetry::SemConv::SERVER::SERVER_ADDRESS, seq_data[:host])
+          end
+
+          # Redis
+          redis_data = span[:data]&.[](:redis)
+          if redis_data
+            add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_SYSTEM, 'redis')
+            add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_QUERY_TEXT, redis_data[:command])
+            add_attribute(attributes, 'db.redis.database_index', redis_data[:db])
+            add_attribute(attributes, OpenTelemetry::SemConv::SERVER::SERVER_ADDRESS, extract_host(redis_data[:connection]))
+            add_attribute(attributes, OpenTelemetry::SemConv::SERVER::SERVER_PORT, extract_port(redis_data[:connection]))
+          end
+
+          # Memcache (Dalli)
+          mc_data = span[:data]&.[](:memcache)
+          if mc_data
+            add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_SYSTEM, 'memcached')
+            add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_OPERATION_NAME, mc_data[:command])
+            add_attribute(attributes, 'db.memcached.key', mc_data[:key])
+            add_attribute(attributes, 'db.memcached.keys', mc_data[:keys])
+            add_attribute(attributes, 'db.memcached.namespace', mc_data[:namespace])
+            add_attribute(attributes, OpenTelemetry::SemConv::SERVER::SERVER_ADDRESS, extract_host(mc_data[:server]))
+            add_attribute(attributes, OpenTelemetry::SemConv::SERVER::SERVER_PORT, extract_port(mc_data[:server]))
+          end
+
+          # MongoDB
+          mongo_data = span[:data]&.[](:mongo)
+          if mongo_data
+            add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_SYSTEM, 'mongodb')
+            add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_NAMESPACE, mongo_data[:namespace])
+            add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_OPERATION_NAME, mongo_data[:command])
+            add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_QUERY_TEXT, mongo_data[:json])
+            add_attribute(attributes, OpenTelemetry::SemConv::SERVER::SERVER_ADDRESS, mongo_data.dig(:peer, :hostname))
+            add_attribute(attributes, OpenTelemetry::SemConv::SERVER::SERVER_PORT, mongo_data.dig(:peer, :port))
+          end
+
+          attributes
+        end
+
+        private
+
+        def extract_host(connection)
+          return nil unless connection
+
+          connection.to_s.split(':').first
+        end
+
+        def extract_port(connection)
+          return nil unless connection
+
+          port = connection.to_s.split(':').last
+          port.to_i if port =~ /^\d+$/
+        end
       end
     end
   end

--- a/lib/instana/exporter/otlp/graphql_converter.rb
+++ b/lib/instana/exporter/otlp/graphql_converter.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# (c) Copyright IBM Corp. 2026
+
+require_relative 'base_converter'
+require 'opentelemetry/semconv/incubating/graphql'
+
+module Instana
+  module Exporter
+    module Otlp
+      # Converter for GraphQL spans to OTLP format
+      class GraphqlConverter < BaseConverter
+        def convert_attributes
+          attributes = {}
+
+          graphql_data = span[:data]&.[](:graphql)
+          return attributes unless graphql_data
+
+          add_attribute(attributes, OpenTelemetry::SemConv::Incubating::GRAPHQL::GRAPHQL_OPERATION_NAME, graphql_data[:operationName])
+          add_attribute(attributes, OpenTelemetry::SemConv::Incubating::GRAPHQL::GRAPHQL_OPERATION_TYPE, graphql_data[:operationType])
+          add_attribute(attributes, OpenTelemetry::SemConv::Incubating::GRAPHQL::GRAPHQL_DOCUMENT, format_fields(graphql_data[:fields]))
+
+          # Add arguments as custom attribute
+          add_attribute(attributes, 'graphql.arguments', format_arguments(graphql_data[:arguments])) if graphql_data[:arguments]
+
+          attributes
+        end
+
+        private
+
+        def format_fields(fields)
+          return nil unless fields
+
+          fields.map { |obj, flds| "#{obj} { #{flds.join(', ')} }" }.join(', ')
+        end
+
+        def format_arguments(arguments)
+          return nil unless arguments
+
+          arguments.map { |obj, args| "#{obj}(#{args.join(', ')})" }.join(', ')
+        end
+      end
+    end
+  end
+end

--- a/lib/instana/exporter/otlp/grpc_converter.rb
+++ b/lib/instana/exporter/otlp/grpc_converter.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# (c) Copyright IBM Corp. 2026
+
+require_relative 'base_converter'
+require 'opentelemetry/semantic_conventions'
+
+module Instana
+  module Exporter
+    module Otlp
+      # Converter for gRPC spans to OTLP format
+      class GrpcConverter < BaseConverter
+        def convert_attributes
+          attributes = {}
+
+          rpc_data = span[:data]&.[](:rpc)
+          return attributes unless rpc_data
+
+          # RPC system
+          add_attribute(attributes, OpenTelemetry::SemanticConventions::Trace::RPC_SYSTEM, 'grpc')
+
+          # RPC service and method
+          if rpc_data[:call]
+            service, method = parse_grpc_call(rpc_data[:call])
+            add_attribute(attributes, OpenTelemetry::SemanticConventions::Trace::RPC_SERVICE, service)
+            add_attribute(attributes, OpenTelemetry::SemanticConventions::Trace::RPC_METHOD, method)
+          end
+
+          # Network peer
+          add_attribute(attributes, OpenTelemetry::SemanticConventions::Trace::NET_PEER_NAME, rpc_data[:host])
+          add_attribute(attributes, OpenTelemetry::SemanticConventions::Trace::NET_PEER_NAME, rpc_data.dig(:peer, :address))
+
+          # gRPC-specific attributes
+          add_attribute(attributes, 'rpc.grpc.call_type', rpc_data[:call_type])
+
+          attributes
+        end
+
+        private
+
+        def parse_grpc_call(call)
+          parts = call.to_s.split('/')
+          return [nil, nil] if parts.size < 3
+
+          [parts[1], parts[2]]
+        end
+      end
+    end
+  end
+end

--- a/lib/instana/exporter/otlp/http_converter.rb
+++ b/lib/instana/exporter/otlp/http_converter.rb
@@ -3,7 +3,10 @@
 # (c) Copyright IBM Corp. 2026
 
 require_relative 'base_converter'
-require 'opentelemetry/semantic_conventions'
+require 'opentelemetry/semconv/http'
+require 'opentelemetry/semconv/url'
+require 'opentelemetry/semconv/server'
+require 'opentelemetry/semconv/user_agent'
 
 module Instana
   module Exporter
@@ -17,13 +20,13 @@ module Instana
           attributes = {}
           http_data = span[:data]&.[](:http) || {}
 
-          add_attribute(attributes, OpenTelemetry::SemanticConventions::Trace::HTTP_METHOD, http_data[:method])
-          add_attribute(attributes, OpenTelemetry::SemanticConventions::Trace::HTTP_URL, http_data[:url])
-          add_attribute(attributes, OpenTelemetry::SemanticConventions::Trace::HTTP_TARGET, http_data[:path])
-          add_attribute(attributes, OpenTelemetry::SemanticConventions::Trace::HTTP_HOST, http_data[:host])
-          add_attribute(attributes, OpenTelemetry::SemanticConventions::Trace::HTTP_SCHEME, extract_scheme(http_data[:url]))
-          add_attribute(attributes, OpenTelemetry::SemanticConventions::Trace::HTTP_STATUS_CODE, http_data[:status])
-          add_attribute(attributes, OpenTelemetry::SemanticConventions::Trace::HTTP_USER_AGENT, http_data.dig(:header, 'user-agent'))
+          add_attribute(attributes, OpenTelemetry::SemConv::HTTP::HTTP_REQUEST_METHOD, http_data[:method])
+          add_attribute(attributes, OpenTelemetry::SemConv::URL::URL_FULL, http_data[:url])
+          add_attribute(attributes, OpenTelemetry::SemConv::URL::URL_PATH, http_data[:path])
+          add_attribute(attributes, OpenTelemetry::SemConv::SERVER::SERVER_ADDRESS, http_data[:host])
+          add_attribute(attributes, OpenTelemetry::SemConv::URL::URL_SCHEME, extract_scheme(http_data[:url]))
+          add_attribute(attributes, OpenTelemetry::SemConv::HTTP::HTTP_RESPONSE_STATUS_CODE, http_data[:status])
+          add_attribute(attributes, OpenTelemetry::SemConv::USER_AGENT::USER_AGENT_ORIGINAL, http_data.dig(:header, 'user-agent'))
 
           attributes
         end

--- a/lib/instana/exporter/otlp/messaging_converter.rb
+++ b/lib/instana/exporter/otlp/messaging_converter.rb
@@ -2,15 +2,33 @@
 
 # (c) Copyright IBM Corp. 2026
 
+require_relative 'base_converter'
+require 'opentelemetry/semconv/incubating/messaging'
+require 'opentelemetry/semconv/server'
+
 module Instana
   module Exporter
     module Otlp
       # Converter for messaging spans to OTLP format
-      # Handles conversion of messaging-related spans (Kafka, RabbitMQ, SQS, etc.)
-      # NOTE: This converter is a placeholder for future implementation
       class MessagingConverter < BaseConverter
-        # Convert messaging span to OTLP format
-        # @return [Hash] Converted messaging span data in OTLP format
+        def convert_attributes
+          attributes = {}
+
+          # RabbitMQ
+          rabbitmq_data = span[:data]&.[](:rabbitmq)
+          if rabbitmq_data
+            add_attribute(attributes, OpenTelemetry::SemConv::Incubating::MESSAGING::MESSAGING_SYSTEM, 'rabbitmq')
+            add_attribute(attributes, OpenTelemetry::SemConv::Incubating::MESSAGING::MESSAGING_DESTINATION_NAME, rabbitmq_data[:exchange])
+            add_attribute(attributes, OpenTelemetry::SemConv::Incubating::MESSAGING::MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY, rabbitmq_data[:key])
+            add_attribute(attributes, 'messaging.rabbitmq.queue', rabbitmq_data[:queue])
+            add_attribute(attributes, OpenTelemetry::SemConv::SERVER::SERVER_ADDRESS, rabbitmq_data[:address])
+
+            operation = rabbitmq_data[:sort] == 'publish' ? 'send' : 'receive'
+            add_attribute(attributes, OpenTelemetry::SemConv::Incubating::MESSAGING::MESSAGING_OPERATION_TYPE, operation)
+          end
+
+          attributes
+        end
       end
     end
   end

--- a/lib/instana/exporter/otlp/rails_converter.rb
+++ b/lib/instana/exporter/otlp/rails_converter.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+# (c) Copyright IBM Corp. 2026
+
+require_relative 'base_converter'
+require 'opentelemetry/semconv/incubating/code'
+
+module Instana
+  module Exporter
+    module Otlp
+      # Converter for Rails-related spans (ActionController, ActionView, ActionMailer) to OTLP format
+      class RailsConverter < BaseConverter
+        def convert_attributes
+          attributes = {}
+
+          case span[:n].to_s
+          when 'actioncontroller'
+            convert_action_controller_attributes(attributes)
+          when 'actionview'
+            convert_action_view_attributes(attributes)
+          when 'render'
+            convert_render_attributes(attributes)
+          when 'mail.actionmailer'
+            convert_action_mailer_attributes(attributes)
+          end
+
+          attributes
+        end
+
+        private
+
+        # Convert ActionController span attributes
+        def convert_action_controller_attributes(attributes)
+          controller_data = span[:data]&.[](:actioncontroller) || span[:actioncontroller]
+          return unless controller_data
+
+          add_attribute(attributes, OpenTelemetry::SemConv::Incubating::CODE::CODE_NAMESPACE, controller_data[:controller])
+          add_attribute(attributes, OpenTelemetry::SemConv::Incubating::CODE::CODE_FUNCTION, controller_data[:action])
+        end
+
+        # Convert ActionView span attributes
+        def convert_action_view_attributes(attributes)
+          view_data = span[:data]&.[](:actionview) || span[:actionview]
+          return unless view_data
+
+          add_attribute(attributes, 'rails.view.name', view_data[:name])
+        end
+
+        # Convert render span attributes
+        def convert_render_attributes(attributes)
+          render_data = span[:data]&.[](:render) || span[:render]
+          return unless render_data
+
+          add_attribute(attributes, 'rails.render.type', render_data[:type])
+          add_attribute(attributes, 'rails.render.name', render_data[:name])
+        end
+
+        # Convert ActionMailer span attributes
+        def convert_action_mailer_attributes(attributes)
+          mailer_data = span[:data]&.[](:actionmailer) || span[:actionmailer]
+          return unless mailer_data
+
+          add_attribute(attributes, OpenTelemetry::SemConv::Incubating::CODE::CODE_NAMESPACE, mailer_data[:class])
+          add_attribute(attributes, OpenTelemetry::SemConv::Incubating::CODE::CODE_FUNCTION, mailer_data[:method])
+        end
+      end
+    end
+  end
+end

--- a/lib/instana/exporter/otlp/rpc_converter.rb
+++ b/lib/instana/exporter/otlp/rpc_converter.rb
@@ -4,7 +4,7 @@
 
 require_relative 'base_converter'
 require 'opentelemetry/semconv/incubating/rpc'
-require 'opentelemetry/semconv/code'
+require 'opentelemetry/semconv/incubating/code'
 require 'opentelemetry/semconv/server'
 
 module Instana
@@ -64,8 +64,8 @@ module Instana
           # Format can be either "ChannelClass" (for transmit) or "ChannelClass#action" (for action dispatch)
           if rpc_data[:call]
             call_parts = rpc_data[:call].to_s.split('#')
-            add_attribute(attributes, OpenTelemetry::SemConv::CODE::CODE_NAMESPACE, call_parts[0])
-            add_attribute(attributes, OpenTelemetry::SemConv::CODE::CODE_FUNCTION, call_parts[1]) if call_parts[1]
+            add_attribute(attributes, OpenTelemetry::SemConv::Incubating::CODE::CODE_NAMESPACE, call_parts[0])
+            add_attribute(attributes, OpenTelemetry::SemConv::Incubating::CODE::CODE_FUNCTION, call_parts[1]) if call_parts[1]
           end
 
           # Network peer

--- a/lib/instana/exporter/otlp/rpc_converter.rb
+++ b/lib/instana/exporter/otlp/rpc_converter.rb
@@ -2,15 +2,82 @@
 
 # (c) Copyright IBM Corp. 2026
 
+require_relative 'base_converter'
+require 'opentelemetry/semconv/incubating/rpc'
+require 'opentelemetry/semconv/code'
+require 'opentelemetry/semconv/server'
+
 module Instana
   module Exporter
     module Otlp
-      # Converter for RPC spans to OTLP format
-      # Handles conversion of RPC-related spans (gRPC, etc.)
-      # NOTE: This converter is a placeholder for future implementation
+      # Converter for RPC spans (gRPC, ActionCable) to OTLP format
       class RpcConverter < BaseConverter
-        # Convert RPC span to OTLP format
-        # @return [Hash] Converted RPC span data in OTLP format
+        def convert_attributes
+          attributes = {}
+
+          rpc_data = span[:data]&.[](:rpc)
+          return attributes unless rpc_data
+
+          # Check if this is an ActionCable span
+          if rpc_data[:flavor] == :actioncable
+            convert_action_cable_attributes(attributes, rpc_data)
+          else
+            convert_grpc_attributes(attributes, rpc_data)
+          end
+
+          attributes
+        end
+
+        private
+
+        # Convert gRPC span attributes
+        def convert_grpc_attributes(attributes, rpc_data)
+          # RPC system
+          add_attribute(attributes, OpenTelemetry::SemConv::Incubating::RPC::RPC_SYSTEM, 'grpc')
+
+          # RPC service and method
+          if rpc_data[:call]
+            service, method = parse_grpc_call(rpc_data[:call])
+            add_attribute(attributes, OpenTelemetry::SemConv::Incubating::RPC::RPC_SERVICE, service)
+            add_attribute(attributes, OpenTelemetry::SemConv::Incubating::RPC::RPC_METHOD, method)
+          end
+
+          # Network peer
+          add_attribute(attributes, OpenTelemetry::SemConv::SERVER::SERVER_ADDRESS, rpc_data[:host])
+          add_attribute(attributes, OpenTelemetry::SemConv::SERVER::SERVER_ADDRESS, rpc_data.dig(:peer, :address))
+
+          # gRPC-specific attributes
+          add_attribute(attributes, 'rpc.grpc.call_type', rpc_data[:call_type])
+        end
+
+        # Convert ActionCable span attributes
+        def convert_action_cable_attributes(attributes, rpc_data)
+          # RPC system
+          add_attribute(attributes, OpenTelemetry::SemConv::Incubating::RPC::RPC_SYSTEM, 'actioncable')
+
+          # ActionCable-specific attributes
+          add_attribute(attributes, 'rails.actioncable.channel', rpc_data[:call])
+          add_attribute(attributes, 'rails.actioncable.call_type', rpc_data[:call_type])
+          add_attribute(attributes, OpenTelemetry::SemConv::Incubating::RPC::RPC_SERVICE, span[:data]&.[](:service) || span[:service])
+
+          # Extract channel class and action from the call attribute
+          # Format can be either "ChannelClass" (for transmit) or "ChannelClass#action" (for action dispatch)
+          if rpc_data[:call]
+            call_parts = rpc_data[:call].to_s.split('#')
+            add_attribute(attributes, OpenTelemetry::SemConv::CODE::CODE_NAMESPACE, call_parts[0])
+            add_attribute(attributes, OpenTelemetry::SemConv::CODE::CODE_FUNCTION, call_parts[1]) if call_parts[1]
+          end
+
+          # Network peer
+          add_attribute(attributes, OpenTelemetry::SemConv::SERVER::SERVER_ADDRESS, rpc_data[:host])
+        end
+
+        def parse_grpc_call(call)
+          parts = call.to_s.split('/')
+          return [nil, nil] if parts.size < 3
+
+          [parts[1], parts[2]]
+        end
       end
     end
   end

--- a/test/exporter/otlp/aws_converter_test.rb
+++ b/test/exporter/otlp/aws_converter_test.rb
@@ -1,0 +1,398 @@
+# frozen_string_literal: true
+
+# (c) Copyright IBM Corp. 2026
+
+require 'test_helper'
+require 'instana/exporter/otlp/aws_converter'
+
+class AwsConverterTest < Minitest::Test # rubocop:disable Metrics/ClassLength
+  # AWS SQS Tests
+  def test_sqs_send_operation_conversion
+    span = create_span('aws.sqs', {
+                         sqs: { queue: 'my-queue', group: 'group-1', size: 5, type: 'send' }
+                       })
+    converter = Instana::Exporter::Otlp::AwsConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    assert_equal 'aws_sqs', attrs['messaging.system']
+    assert_equal 'my-queue', attrs['messaging.destination.name']
+    assert_equal 'group-1', attrs['messaging.aws.sqs.message_group_id']
+    assert_equal 5, attrs['messaging.batch.message_count']
+    assert_equal 'send', attrs['messaging.operation.type']
+  end
+
+  def test_sqs_single_sync_operation_conversion
+    span = create_span('aws.sqs', {
+                         sqs: { queue: 'test-queue', type: 'single.sync' }
+                       })
+    converter = Instana::Exporter::Otlp::AwsConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    assert_equal 'aws_sqs', attrs['messaging.system']
+    assert_equal 'test-queue', attrs['messaging.destination.name']
+    assert_equal 'send', attrs['messaging.operation.type']
+  end
+
+  def test_sqs_delete_operation_conversion
+    span = create_span('aws.sqs', {
+                         sqs: { queue: 'delete-queue', type: 'delete' }
+                       })
+    converter = Instana::Exporter::Otlp::AwsConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    assert_equal 'aws_sqs', attrs['messaging.system']
+    assert_equal 'delete-queue', attrs['messaging.destination.name']
+    assert_equal 'process', attrs['messaging.operation.type']
+  end
+
+  def test_sqs_create_operation_conversion
+    span = create_span('aws.sqs', {
+                         sqs: { queue: 'new-queue', type: 'create' }
+                       })
+    converter = Instana::Exporter::Otlp::AwsConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    assert_equal 'aws_sqs', attrs['messaging.system']
+    assert_equal 'new-queue', attrs['messaging.destination.name']
+    assert_equal 'create', attrs['messaging.operation.type']
+  end
+
+  def test_sqs_get_operation_conversion
+    span = create_span('aws.sqs', {
+                         sqs: { queue: 'get-queue', type: 'get' }
+                       })
+    converter = Instana::Exporter::Otlp::AwsConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    assert_equal 'aws_sqs', attrs['messaging.system']
+    assert_equal 'get-queue', attrs['messaging.destination.name']
+    assert_equal 'create', attrs['messaging.operation.type']
+  end
+
+  def test_sqs_unknown_operation_defaults_to_send
+    span = create_span('aws.sqs', {
+                         sqs: { queue: 'unknown-queue', type: 'unknown_operation' }
+                       })
+    converter = Instana::Exporter::Otlp::AwsConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    assert_equal 'send', attrs['messaging.operation.type']
+  end
+
+  def test_sqs_with_nil_values
+    span = create_span('aws.sqs', {
+                         sqs: { queue: 'test-queue', group: nil, size: nil, type: 'send' }
+                       })
+    converter = Instana::Exporter::Otlp::AwsConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    assert_equal 'aws_sqs', attrs['messaging.system']
+    assert_equal 'test-queue', attrs['messaging.destination.name']
+    assert_nil attrs['messaging.aws.sqs.message_group_id']
+    assert_nil attrs['messaging.batch.message_count']
+  end
+
+  # AWS SNS Tests
+  def test_sns_basic_conversion
+    span = create_span('aws.sns', {
+                         sns: { topic: 'my-topic', target: 'arn:aws:sns:us-east-1:123456789:my-topic' }
+                       })
+    converter = Instana::Exporter::Otlp::AwsConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    assert_equal 'aws_sns', attrs['messaging.system']
+    assert_equal 'my-topic', attrs['messaging.destination.name']
+    assert_equal 'arn:aws:sns:us-east-1:123456789:my-topic', attrs['messaging.aws.sns.target_arn']
+    assert_equal 'send', attrs['messaging.operation.type']
+  end
+
+  def test_sns_with_phone_number
+    span = create_span('aws.sns', {
+                         sns: { topic: 'sms-topic', phone: '+1234567890' }
+                       })
+    converter = Instana::Exporter::Otlp::AwsConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    assert_equal 'aws_sns', attrs['messaging.system']
+    assert_equal '+1234567890', attrs['messaging.aws.sns.phone_number']
+  end
+
+  def test_sns_with_subject
+    span = create_span('aws.sns', {
+                         sns: { topic: 'notification-topic', subject: 'Important Alert' }
+                       })
+    converter = Instana::Exporter::Otlp::AwsConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    assert_equal 'aws_sns', attrs['messaging.system']
+    assert_equal 'Important Alert', attrs['messaging.aws.sns.subject']
+  end
+
+  def test_sns_with_all_attributes
+    span = create_span('aws.sns', {
+                         sns: {
+                           topic: 'full-topic',
+                           target: 'arn:aws:sns:us-west-2:987654321:full-topic',
+                           phone: '+9876543210',
+                           subject: 'Test Subject'
+                         }
+                       })
+    converter = Instana::Exporter::Otlp::AwsConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    assert_equal 'aws_sns', attrs['messaging.system']
+    assert_equal 'full-topic', attrs['messaging.destination.name']
+    assert_equal 'arn:aws:sns:us-west-2:987654321:full-topic', attrs['messaging.aws.sns.target_arn']
+    assert_equal '+9876543210', attrs['messaging.aws.sns.phone_number']
+    assert_equal 'Test Subject', attrs['messaging.aws.sns.subject']
+    assert_equal 'send', attrs['messaging.operation.type']
+  end
+
+  # AWS DynamoDB Tests
+  def test_dynamodb_basic_conversion
+    span = create_span('aws.dynamodb', {
+                         dynamodb: { op: 'GetItem', table: 'users-table' }
+                       })
+    converter = Instana::Exporter::Otlp::AwsConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    assert_equal 'dynamodb', attrs['db.system.name']
+    assert_equal 'GetItem', attrs['db.operation.name']
+    assert_equal 'users-table', attrs['db.namespace']
+    assert_equal 'users-table', attrs['aws.dynamodb.table_name']
+  end
+
+  def test_dynamodb_put_item_operation
+    span = create_span('aws.dynamodb', {
+                         dynamodb: { op: 'PutItem', table: 'orders-table' }
+                       })
+    converter = Instana::Exporter::Otlp::AwsConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    assert_equal 'dynamodb', attrs['db.system.name']
+    assert_equal 'PutItem', attrs['db.operation.name']
+    assert_equal 'orders-table', attrs['db.namespace']
+    assert_equal 'orders-table', attrs['aws.dynamodb.table_name']
+  end
+
+  def test_dynamodb_query_operation
+    span = create_span('aws.dynamodb', {
+                         dynamodb: { op: 'Query', table: 'products-table' }
+                       })
+    converter = Instana::Exporter::Otlp::AwsConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    assert_equal 'dynamodb', attrs['db.system.name']
+    assert_equal 'Query', attrs['db.operation.name']
+    assert_equal 'products-table', attrs['db.namespace']
+  end
+
+  def test_dynamodb_scan_operation
+    span = create_span('aws.dynamodb', {
+                         dynamodb: { op: 'Scan', table: 'analytics-table' }
+                       })
+    converter = Instana::Exporter::Otlp::AwsConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    assert_equal 'dynamodb', attrs['db.system.name']
+    assert_equal 'Scan', attrs['db.operation.name']
+    assert_equal 'analytics-table', attrs['db.namespace']
+  end
+
+  # AWS S3 Tests
+  def test_s3_basic_conversion
+    span = create_span('aws.s3', {
+                         s3: { bucket: 'my-bucket', key: 'path/to/file.txt', op: 'GetObject' }
+                       })
+    converter = Instana::Exporter::Otlp::AwsConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    assert_equal 's3', attrs['aws.service']
+    assert_equal 'my-bucket', attrs['aws.s3.bucket']
+    assert_equal 'path/to/file.txt', attrs['aws.s3.key']
+    assert_equal 'GetObject', attrs['aws.s3.operation']
+  end
+
+  def test_s3_put_object_operation
+    span = create_span('aws.s3', {
+                         s3: { bucket: 'uploads-bucket', key: 'uploads/image.jpg', op: 'PutObject' }
+                       })
+    converter = Instana::Exporter::Otlp::AwsConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    assert_equal 's3', attrs['aws.service']
+    assert_equal 'uploads-bucket', attrs['aws.s3.bucket']
+    assert_equal 'uploads/image.jpg', attrs['aws.s3.key']
+    assert_equal 'PutObject', attrs['aws.s3.operation']
+  end
+
+  def test_s3_delete_object_operation
+    span = create_span('aws.s3', {
+                         s3: { bucket: 'temp-bucket', key: 'temp/file.tmp', op: 'DeleteObject' }
+                       })
+    converter = Instana::Exporter::Otlp::AwsConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    assert_equal 's3', attrs['aws.service']
+    assert_equal 'temp-bucket', attrs['aws.s3.bucket']
+    assert_equal 'temp/file.tmp', attrs['aws.s3.key']
+    assert_equal 'DeleteObject', attrs['aws.s3.operation']
+  end
+
+  def test_s3_list_objects_operation
+    span = create_span('aws.s3', {
+                         s3: { bucket: 'data-bucket', op: 'ListObjects' }
+                       })
+    converter = Instana::Exporter::Otlp::AwsConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    assert_equal 's3', attrs['aws.service']
+    assert_equal 'data-bucket', attrs['aws.s3.bucket']
+    assert_nil attrs['aws.s3.key']
+    assert_equal 'ListObjects', attrs['aws.s3.operation']
+  end
+
+  # AWS Lambda Tests
+  def test_lambda_basic_conversion
+    span = create_span('aws.lambda', {
+                         aws: {
+                           lambda: {
+                             invoke: { function: 'my-function', type: 'RequestResponse' }
+                           }
+                         }
+                       })
+    converter = Instana::Exporter::Otlp::AwsConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    assert_equal 'lambda', attrs['aws.service']
+    assert_equal 'my-function', attrs['aws.lambda.function_name']
+    assert_equal 'RequestResponse', attrs['aws.lambda.invocation_type']
+    assert_equal 'my-function', attrs['faas.invoked_name']
+  end
+
+  def test_lambda_event_invocation
+    span = create_span('aws.lambda', {
+                         aws: {
+                           lambda: {
+                             invoke: { function: 'async-function', type: 'Event' }
+                           }
+                         }
+                       })
+    converter = Instana::Exporter::Otlp::AwsConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    assert_equal 'lambda', attrs['aws.service']
+    assert_equal 'async-function', attrs['aws.lambda.function_name']
+    assert_equal 'Event', attrs['aws.lambda.invocation_type']
+    assert_equal 'async-function', attrs['faas.invoked_name']
+  end
+
+  def test_lambda_dry_run_invocation
+    span = create_span('aws.lambda', {
+                         aws: {
+                           lambda: {
+                             invoke: { function: 'test-function', type: 'DryRun' }
+                           }
+                         }
+                       })
+    converter = Instana::Exporter::Otlp::AwsConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    assert_equal 'lambda', attrs['aws.service']
+    assert_equal 'test-function', attrs['aws.lambda.function_name']
+    assert_equal 'DryRun', attrs['aws.lambda.invocation_type']
+  end
+
+  # Edge Cases and Mixed Tests
+  def test_empty_span_data
+    span = create_span('aws.unknown', {})
+    converter = Instana::Exporter::Otlp::AwsConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    assert_empty attrs
+  end
+
+  def test_nil_span_data
+    span = Instana::Span.new('aws.test'.to_sym)
+    span[:data] = nil
+    span.close
+    converter = Instana::Exporter::Otlp::AwsConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    assert_empty attrs
+  end
+
+  def test_multiple_aws_services_in_same_span
+    # This shouldn't happen in practice, but test defensive coding
+    span = create_span('aws.mixed', {
+                         sqs: { queue: 'test-queue', type: 'send' },
+                         sns: { topic: 'test-topic' }
+                       })
+    converter = Instana::Exporter::Otlp::AwsConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    # SNS overwrites SQS since both set messaging.system and messaging.destination.name
+    # In practice, a span should only have one AWS service type
+    assert_equal 'aws_sns', attrs['messaging.system']
+    assert_equal 'test-topic', attrs['messaging.destination.name']
+    assert_equal 'send', attrs['messaging.operation.type']
+  end
+
+  def test_converter_inherits_from_base_converter
+    span = create_span('aws.sqs', { sqs: { queue: 'test' } })
+    converter = Instana::Exporter::Otlp::AwsConverter.new(span)
+
+    assert_kind_of Instana::Exporter::Otlp::BaseConverter, converter
+  end
+
+  def test_full_span_conversion_with_sqs
+    span = create_span('aws.sqs', {
+                         sqs: { queue: 'integration-queue', type: 'send', size: 10 }
+                       })
+    converter = Instana::Exporter::Otlp::AwsConverter.new(span)
+    result = converter.convert
+
+    # Verify base attributes are present
+    assert result[:trace_id]
+    assert result[:span_id]
+    assert result[:name]
+    assert result[:kind]
+    assert result[:start_timestamp]
+    assert result[:end_timestamp]
+    assert result[:status]
+    assert result[:attributes]
+
+    # Verify AWS-specific attributes
+    attrs = result[:attributes]
+    assert_equal 'aws_sqs', attrs['messaging.system']
+    assert_equal 'integration-queue', attrs['messaging.destination.name']
+  end
+
+  def test_full_span_conversion_with_dynamodb
+    span = create_span('aws.dynamodb', {
+                         dynamodb: { op: 'BatchGetItem', table: 'batch-table' }
+                       })
+    converter = Instana::Exporter::Otlp::AwsConverter.new(span)
+    result = converter.convert
+
+    # Verify base attributes are present
+    assert result[:trace_id]
+    assert result[:span_id]
+    assert result[:attributes]
+
+    # Verify DynamoDB-specific attributes
+    attrs = result[:attributes]
+    assert_equal 'dynamodb', attrs['db.system.name']
+    assert_equal 'BatchGetItem', attrs['db.operation.name']
+    assert_equal 'batch-table', attrs['db.namespace']
+  end
+
+  private
+
+  def create_span(name, data)
+    span = Instana::Span.new(name.to_sym)
+    span[:data] = data
+    span.close
+    span
+  end
+end

--- a/test/exporter/otlp/background_job_converter_test.rb
+++ b/test/exporter/otlp/background_job_converter_test.rb
@@ -1,0 +1,95 @@
+# (c) Copyright IBM Corp. 2026
+
+require 'test_helper'
+require 'instana/exporter/otlp/background_job_converter'
+
+class BackgroundJobConverterTest < Minitest::Test
+  def test_sidekiq_client_conversion
+    span = create_span('sidekiq-client', {
+                         'sidekiq-client': { queue: 'default', job_id: '123', job: 'TestWorker', 'redis-url': 'localhost:6379' }
+                       })
+    converter = Instana::Exporter::Otlp::BackgroundJobConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    assert_equal 'sidekiq', attrs['messaging.system']
+    assert_equal 'default', attrs['messaging.destination.name']
+    assert_equal 'publish', attrs['messaging.operation']
+    assert_equal '123', attrs['messaging.message.id']
+    assert_equal 'TestWorker', attrs['messaging.consumer.group.name']
+    assert_equal 'localhost', attrs['server.address']
+    assert_equal 6379, attrs['server.port']
+  end
+
+  def test_sidekiq_worker_conversion
+    span = create_span('sidekiq-worker', {
+                         'sidekiq-worker': { queue: 'critical', job_id: '456', job: 'EmailWorker', 'redis-url': 'redis.local:6380' }
+                       })
+    converter = Instana::Exporter::Otlp::BackgroundJobConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    assert_equal 'sidekiq', attrs['messaging.system']
+    assert_equal 'critical', attrs['messaging.destination.name']
+    assert_equal 'process', attrs['messaging.operation']
+    assert_equal '456', attrs['messaging.message.id']
+    assert_equal 'EmailWorker', attrs['messaging.consumer.group.name']
+  end
+
+  def test_resque_client_conversion
+    span = create_span('resque-client', {
+                         'resque-client': { queue: 'low', job_id: '789', job: 'ReportWorker', 'redis-url': '127.0.0.1:6379' }
+                       })
+    converter = Instana::Exporter::Otlp::BackgroundJobConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    assert_equal 'resque', attrs['messaging.system']
+    assert_equal 'low', attrs['messaging.destination.name']
+    assert_equal 'publish', attrs['messaging.operation']
+  end
+
+  def test_resque_worker_conversion
+    span = create_span('resque-worker', {
+                         'resque-worker': { queue: 'high', job_id: '101', job: 'DataWorker' }
+                       })
+    converter = Instana::Exporter::Otlp::BackgroundJobConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    assert_equal 'resque', attrs['messaging.system']
+    assert_equal 'process', attrs['messaging.operation']
+  end
+
+  def test_extract_host
+    span = create_span('sidekiq-client', {})
+    converter = Instana::Exporter::Otlp::BackgroundJobConverter.new(span)
+
+    assert_equal 'localhost', converter.send(:extract_host, 'localhost:6379')
+    assert_equal 'redis.local', converter.send(:extract_host, 'redis.local:6380')
+    assert_nil converter.send(:extract_host, nil)
+  end
+
+  def test_extract_port
+    span = create_span('sidekiq-client', {})
+    converter = Instana::Exporter::Otlp::BackgroundJobConverter.new(span)
+
+    assert_equal 6379, converter.send(:extract_port, 'localhost:6379')
+    assert_equal 6380, converter.send(:extract_port, 'redis.local:6380')
+    assert_nil converter.send(:extract_port, 'invalid')
+    assert_nil converter.send(:extract_port, nil)
+  end
+
+  def test_missing_data
+    span = create_span('sidekiq-client', {})
+    converter = Instana::Exporter::Otlp::BackgroundJobConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    assert_empty attrs
+  end
+
+  private
+
+  def create_span(name, data)
+    span = Instana::Span.new(name.to_sym)
+    span[:data] = data
+    span.close
+    span
+  end
+end

--- a/test/exporter/otlp/converter_factory_test.rb
+++ b/test/exporter/otlp/converter_factory_test.rb
@@ -189,6 +189,7 @@ class ConverterFactoryTest < Minitest::Test
       'http' => 'Instana::Exporter::Otlp::HttpConverter',
       'database' => 'Instana::Exporter::Otlp::DatabaseConverter',
       'messaging' => 'Instana::Exporter::Otlp::MessagingConverter',
+      'background_job' => 'Instana::Exporter::Otlp::BackgroundJobConverter',
       'rpc' => 'Instana::Exporter::Otlp::RpcConverter',
       'custom' => 'Instana::Exporter::Otlp::CustomConverter',
       'internal' => 'Instana::Exporter::Otlp::InternalConverter'
@@ -221,6 +222,14 @@ class ConverterFactoryTest < Minitest::Test
     refute @factory.send(:messaging_span?, create_test_span(name: :http))
   end
 
+  def test_background_job_span_detection
+    assert @factory.send(:background_job_span?, create_test_span(name: 'sidekiq-client'))
+    assert @factory.send(:background_job_span?, create_test_span(name: 'sidekiq-worker'))
+    assert @factory.send(:background_job_span?, create_test_span(name: 'resque-client'))
+    assert @factory.send(:background_job_span?, create_test_span(name: 'resque-worker'))
+    refute @factory.send(:background_job_span?, create_test_span(name: :http))
+  end
+
   def test_rpc_span_detection
     assert @factory.send(:rpc_span?, create_test_span(name: 'grpc'))
     refute @factory.send(:rpc_span?, create_test_span(name: :http))
@@ -249,11 +258,29 @@ class ConverterFactoryTest < Minitest::Test
     assert_equal 'Instana::Exporter::Otlp::InternalConverter', converter.class.name
   end
 
+  def test_returns_background_job_converter_for_background_job_spans
+    %w[sidekiq-client sidekiq-worker resque-client resque-worker].each do |name|
+      span = create_test_span(name: name)
+      converter = @factory.create(span)
+
+      assert_equal 'Instana::Exporter::Otlp::BackgroundJobConverter', converter.class.name,
+                   "Should return BackgroundJobConverter for '#{name}' span"
+    end
+  end
+
+  def test_determine_span_type_returns_background_job
+    span = create_test_span(name: 'sidekiq-client')
+    span_type = @factory.send(:determine_span_type, span)
+
+    assert_equal 'background_job', span_type
+  end
+
   def test_case_insensitive_detection
     test_cases = {
       'rack' => 'Instana::Exporter::Otlp::HttpConverter',
       'SQL' => 'Instana::Exporter::Otlp::DatabaseConverter',
       'KAFKA' => 'Instana::Exporter::Otlp::MessagingConverter',
+      'SIDEKIQ-CLIENT' => 'Instana::Exporter::Otlp::BackgroundJobConverter',
       'GRPC' => 'Instana::Exporter::Otlp::RpcConverter',
       'CUSTOM' => 'Instana::Exporter::Otlp::CustomConverter'
     }

--- a/test/exporter/otlp/custom_converter_test.rb
+++ b/test/exporter/otlp/custom_converter_test.rb
@@ -3,11 +3,45 @@
 require 'test_helper'
 require 'instana/exporter/otlp/custom_converter'
 
-# Stub test file for CustomConverter
-# TODO: Add comprehensive tests for custom span conversion
 class CustomConverterTest < Minitest::Test
-  def test_stub
-    # Placeholder test - implement actual tests when CustomConverter is fully implemented
-    skip 'CustomConverter is a stub - tests to be implemented'
+  def test_converts_instana_sdk_custom_span_attributes
+    span = Instana::Span.new(:my_custom_span)
+    span[:data] = { sdk: { name: 'my_custom_span', type: 'custom' } }
+    span.close
+
+    attributes = Instana::Exporter::Otlp::CustomConverter.new(span).convert.attributes
+
+    assert_equal 'custom', attributes['instana.span.type']
+    assert_equal 'my_custom_span', attributes['instana.sdk.name']
+    assert_equal 'custom', attributes['instana.sdk.type']
+  end
+
+  def test_converts_custom_tags
+    span = Instana::Span.new(:my_custom_span)
+    span.set_tag('user.id', 123)
+    span.set_tag('request.path', '/api/users')
+    span.close
+
+    attributes = Instana::Exporter::Otlp::CustomConverter.new(span).convert.attributes
+
+    assert_equal 123, attributes['user.id']
+    assert_equal '/api/users', attributes['request.path']
+  end
+
+  def test_converts_custom_tags_from_data_hash
+    span = Instana::Span.new(:my_custom_span)
+    span[:data] = {
+      sdk: {
+        custom: {
+          tags: { 'param1' => 'value1', 'param2' => 42 }
+        }
+      }
+    }
+    span.close
+
+    attributes = Instana::Exporter::Otlp::CustomConverter.new(span).convert.attributes
+
+    assert_equal 'value1', attributes['param1']
+    assert_equal 42, attributes['param2']
   end
 end

--- a/test/exporter/otlp/database_converter_test.rb
+++ b/test/exporter/otlp/database_converter_test.rb
@@ -6,8 +6,8 @@ require 'instana/exporter/otlp/database_converter'
 class DatabaseConverterTest < Minitest::Test
   def test_activerecord_conversion
     span = create_span(:activerecord, {
-      activerecord: { adapter: 'postgresql', db: 'mydb', sql: 'SELECT * FROM users', username: 'admin', host: 'db.example.com' }
-    })
+                         activerecord: { adapter: 'postgresql', db: 'mydb', sql: 'SELECT * FROM users', username: 'admin', host: 'db.example.com' }
+                       })
     converter = Instana::Exporter::Otlp::DatabaseConverter.new(span)
     attrs = converter.send(:convert_attributes)
 
@@ -20,8 +20,8 @@ class DatabaseConverterTest < Minitest::Test
 
   def test_sequel_conversion
     span = create_span(:sequel, {
-      sequel: { adapter: 'mysql2', db: 'testdb', sql: 'INSERT INTO logs', username: 'root', host: 'localhost' }
-    })
+                         sequel: { adapter: 'mysql2', db: 'testdb', sql: 'INSERT INTO logs', username: 'root', host: 'localhost' }
+                       })
     converter = Instana::Exporter::Otlp::DatabaseConverter.new(span)
     attrs = converter.send(:convert_attributes)
 
@@ -34,8 +34,8 @@ class DatabaseConverterTest < Minitest::Test
 
   def test_redis_conversion
     span = create_span(:redis, {
-      redis: { command: 'GET key', db: 2, connection: 'redis.local:6379' }
-    })
+                         redis: { command: 'GET key', db: 2, connection: 'redis.local:6379' }
+                       })
     converter = Instana::Exporter::Otlp::DatabaseConverter.new(span)
     attrs = converter.send(:convert_attributes)
 
@@ -48,8 +48,8 @@ class DatabaseConverterTest < Minitest::Test
 
   def test_memcache_conversion
     span = create_span(:memcache, {
-      memcache: { command: 'get', key: 'user:123', namespace: 'app', server: '127.0.0.1:11211' }
-    })
+                         memcache: { command: 'get', key: 'user:123', namespace: 'app', server: '127.0.0.1:11211' }
+                       })
     converter = Instana::Exporter::Otlp::DatabaseConverter.new(span)
     attrs = converter.send(:convert_attributes)
 
@@ -63,8 +63,8 @@ class DatabaseConverterTest < Minitest::Test
 
   def test_memcache_with_keys
     span = create_span(:memcache, {
-      memcache: { command: 'get_multi', keys: ['key1', 'key2'], server: 'localhost:11211' }
-    })
+                         memcache: { command: 'get_multi', keys: ['key1', 'key2'], server: 'localhost:11211' }
+                       })
     converter = Instana::Exporter::Otlp::DatabaseConverter.new(span)
     attrs = converter.send(:convert_attributes)
 
@@ -73,8 +73,8 @@ class DatabaseConverterTest < Minitest::Test
 
   def test_mongodb_conversion
     span = create_span(:mongo, {
-      mongo: { namespace: 'mydb.users', command: 'find', json: '{"name":"John"}', peer: { hostname: 'mongo.local', port: 27017 } }
-    })
+                         mongo: { namespace: 'mydb.users', command: 'find', json: '{"name":"John"}', peer: { hostname: 'mongo.local', port: 27017 } }
+                       })
     converter = Instana::Exporter::Otlp::DatabaseConverter.new(span)
     attrs = converter.send(:convert_attributes)
 

--- a/test/exporter/otlp/database_converter_test.rb
+++ b/test/exporter/otlp/database_converter_test.rb
@@ -3,11 +3,122 @@
 require 'test_helper'
 require 'instana/exporter/otlp/database_converter'
 
-# Stub test file for DatabaseConverter
-# TODO: Add comprehensive tests for database span conversion
 class DatabaseConverterTest < Minitest::Test
-  def test_stub
-    # Placeholder test - implement actual tests when DatabaseConverter is fully implemented
-    skip 'DatabaseConverter is a stub - tests to be implemented'
+  def test_activerecord_conversion
+    span = create_span(:activerecord, {
+      activerecord: { adapter: 'postgresql', db: 'mydb', sql: 'SELECT * FROM users', username: 'admin', host: 'db.example.com' }
+    })
+    converter = Instana::Exporter::Otlp::DatabaseConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    assert_equal 'postgresql', attrs['db.system.name']
+    assert_equal 'mydb', attrs['db.namespace']
+    assert_equal 'SELECT * FROM users', attrs['db.query.text']
+    assert_equal 'admin', attrs['db.user']
+    assert_equal 'db.example.com', attrs['server.address']
+  end
+
+  def test_sequel_conversion
+    span = create_span(:sequel, {
+      sequel: { adapter: 'mysql2', db: 'testdb', sql: 'INSERT INTO logs', username: 'root', host: 'localhost' }
+    })
+    converter = Instana::Exporter::Otlp::DatabaseConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    assert_equal 'mysql2', attrs['db.system.name']
+    assert_equal 'testdb', attrs['db.namespace']
+    assert_equal 'INSERT INTO logs', attrs['db.query.text']
+    assert_equal 'root', attrs['db.user']
+    assert_equal 'localhost', attrs['server.address']
+  end
+
+  def test_redis_conversion
+    span = create_span(:redis, {
+      redis: { command: 'GET key', db: 2, connection: 'redis.local:6379' }
+    })
+    converter = Instana::Exporter::Otlp::DatabaseConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    assert_equal 'redis', attrs['db.system.name']
+    assert_equal 'GET key', attrs['db.query.text']
+    assert_equal 2, attrs['db.redis.database_index']
+    assert_equal 'redis.local', attrs['server.address']
+    assert_equal 6379, attrs['server.port']
+  end
+
+  def test_memcache_conversion
+    span = create_span(:memcache, {
+      memcache: { command: 'get', key: 'user:123', namespace: 'app', server: '127.0.0.1:11211' }
+    })
+    converter = Instana::Exporter::Otlp::DatabaseConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    assert_equal 'memcached', attrs['db.system.name']
+    assert_equal 'get', attrs['db.operation.name']
+    assert_equal 'user:123', attrs['db.memcached.key']
+    assert_equal 'app', attrs['db.memcached.namespace']
+    assert_equal '127.0.0.1', attrs['server.address']
+    assert_equal 11211, attrs['server.port']
+  end
+
+  def test_memcache_with_keys
+    span = create_span(:memcache, {
+      memcache: { command: 'get_multi', keys: ['key1', 'key2'], server: 'localhost:11211' }
+    })
+    converter = Instana::Exporter::Otlp::DatabaseConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    assert_equal ['key1', 'key2'], attrs['db.memcached.keys']
+  end
+
+  def test_mongodb_conversion
+    span = create_span(:mongo, {
+      mongo: { namespace: 'mydb.users', command: 'find', json: '{"name":"John"}', peer: { hostname: 'mongo.local', port: 27017 } }
+    })
+    converter = Instana::Exporter::Otlp::DatabaseConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    assert_equal 'mongodb', attrs['db.system.name']
+    assert_equal 'mydb.users', attrs['db.namespace']
+    assert_equal 'find', attrs['db.operation.name']
+    assert_equal '{"name":"John"}', attrs['db.query.text']
+    assert_equal 'mongo.local', attrs['server.address']
+    assert_equal 27017, attrs['server.port']
+  end
+
+  def test_extract_host
+    span = create_span(:redis, {})
+    converter = Instana::Exporter::Otlp::DatabaseConverter.new(span)
+
+    assert_equal 'localhost', converter.send(:extract_host, 'localhost:6379')
+    assert_equal 'redis.local', converter.send(:extract_host, 'redis.local:6380')
+    assert_nil converter.send(:extract_host, nil)
+  end
+
+  def test_extract_port
+    span = create_span(:redis, {})
+    converter = Instana::Exporter::Otlp::DatabaseConverter.new(span)
+
+    assert_equal 6379, converter.send(:extract_port, 'localhost:6379')
+    assert_equal 11211, converter.send(:extract_port, '127.0.0.1:11211')
+    assert_nil converter.send(:extract_port, 'invalid')
+    assert_nil converter.send(:extract_port, nil)
+  end
+
+  def test_missing_data
+    span = create_span(:activerecord, {})
+    converter = Instana::Exporter::Otlp::DatabaseConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    assert_empty attrs
+  end
+
+  private
+
+  def create_span(name, data)
+    span = Instana::Span.new(name)
+    span[:data] = data
+    span.close
+    span
   end
 end

--- a/test/exporter/otlp/graphql_converter_test.rb
+++ b/test/exporter/otlp/graphql_converter_test.rb
@@ -1,0 +1,90 @@
+# (c) Copyright IBM Corp. 2026
+
+require 'test_helper'
+require 'instana/exporter/otlp/graphql_converter'
+
+class GraphqlConverterTest < Minitest::Test
+  def test_convert_attributes_with_full_data
+    span = create_span({
+                         operationName: 'GetUser',
+                         operationType: 'query',
+                         fields: { User: %w[id name email], Profile: %w[bio avatar] },
+                         arguments: { User: %w[id:123], Profile: %w[userId:123] }
+                       })
+    converter = Instana::Exporter::Otlp::GraphqlConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    assert_equal 'GetUser', attrs['graphql.operation.name']
+    assert_equal 'query', attrs['graphql.operation.type']
+    assert_equal 'User { id, name, email }, Profile { bio, avatar }', attrs['graphql.document']
+    assert_equal 'User(id:123), Profile(userId:123)', attrs['graphql.arguments']
+  end
+
+  def test_convert_attributes_without_arguments
+    span = create_span({
+                         operationName: 'ListPosts',
+                         operationType: 'query',
+                         fields: { Post: %w[title content] }
+                       })
+    converter = Instana::Exporter::Otlp::GraphqlConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    assert_equal 'ListPosts', attrs['graphql.operation.name']
+    assert_equal 'query', attrs['graphql.operation.type']
+    assert_equal 'Post { title, content }', attrs['graphql.document']
+    refute attrs.key?('graphql.arguments')
+  end
+
+  def test_convert_attributes_mutation
+    span = create_span({
+                         operationName: 'CreateUser',
+                         operationType: 'mutation',
+                         fields: { User: %w[id name] },
+                         arguments: { User: ['name:"John"', 'email:"john@example.com"'] }
+                       })
+    converter = Instana::Exporter::Otlp::GraphqlConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    assert_equal 'CreateUser', attrs['graphql.operation.name']
+    assert_equal 'mutation', attrs['graphql.operation.type']
+    assert_equal 'User(name:"John", email:"john@example.com")', attrs['graphql.arguments']
+  end
+
+  def test_convert_attributes_no_data
+    span = Instana::Span.new(:graphql)
+    span.close
+    converter = Instana::Exporter::Otlp::GraphqlConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    assert_empty attrs
+  end
+
+  def test_format_fields
+    span = create_span({})
+    converter = Instana::Exporter::Otlp::GraphqlConverter.new(span)
+
+    result = converter.send(:format_fields, { User: %w[id name], Post: %w[title] })
+    assert_equal 'User { id, name }, Post { title }', result
+
+    assert_nil converter.send(:format_fields, nil)
+  end
+
+  def test_format_arguments
+    span = create_span({})
+    converter = Instana::Exporter::Otlp::GraphqlConverter.new(span)
+
+    result = converter.send(:format_arguments, { User: %w[id:1], Post: %w[limit:10] })
+    assert_equal 'User(id:1), Post(limit:10)', result
+
+    assert_nil converter.send(:format_arguments, nil)
+  end
+
+  private
+
+  def create_span(graphql_data)
+    span = Instana::Span.new(:graphql)
+    span[:data] = { graphql: graphql_data } unless graphql_data.empty?
+    span.close
+    span
+  end
+end

--- a/test/exporter/otlp/http_converter_test.rb
+++ b/test/exporter/otlp/http_converter_test.rb
@@ -36,15 +36,15 @@ class HttpConverterTest < Minitest::Test
     assert_equal 'nethttp', result[:name]
     assert_equal :client, result[:kind] # CLIENT kind
 
-    # Verify HTTP attributes are present
+    # Verify HTTP attributes are present (using new semantic conventions)
     attributes = result[:attributes]
-    assert_http_attribute(attributes, 'http.method', 'GET')
-    assert_http_attribute(attributes, 'http.url', 'https://api.example.com/users/123')
-    assert_http_attribute(attributes, 'http.status_code', 200)
-    assert_http_attribute(attributes, 'http.host', 'api.example.com')
-    assert_http_attribute(attributes, 'http.target', '/users/123')
-    assert_http_attribute(attributes, 'http.scheme', 'https')
-    assert_http_attribute(attributes, 'http.user_agent', 'Ruby/3.2.0')
+    assert_http_attribute(attributes, 'http.request.method', 'GET')
+    assert_http_attribute(attributes, 'url.full', 'https://api.example.com/users/123')
+    assert_http_attribute(attributes, 'http.response.status_code', 200)
+    assert_http_attribute(attributes, 'server.address', 'api.example.com')
+    assert_http_attribute(attributes, 'url.path', '/users/123')
+    assert_http_attribute(attributes, 'url.scheme', 'https')
+    assert_http_attribute(attributes, 'user_agent.original', 'Ruby/3.2.0')
   end
 
   def test_convert_http_server_span
@@ -62,8 +62,8 @@ class HttpConverterTest < Minitest::Test
 
     assert_equal :server, result[:kind] # SERVER kind
     attributes = result[:attributes]
-    assert_http_attribute(attributes, 'http.method', 'POST')
-    assert_http_attribute(attributes, 'http.status_code', 201)
+    assert_http_attribute(attributes, 'http.request.method', 'POST')
+    assert_http_attribute(attributes, 'http.response.status_code', 201)
   end
 
   def test_convert_http_span_with_minimal_data
@@ -79,7 +79,7 @@ class HttpConverterTest < Minitest::Test
 
     # Should have at least the method attribute
     attributes = result[:attributes]
-    assert_http_attribute(attributes, 'http.method', 'GET')
+    assert_http_attribute(attributes, 'http.request.method', 'GET')
   end
 
   def test_convert_http_span_without_http_data
@@ -101,7 +101,7 @@ class HttpConverterTest < Minitest::Test
     result = converter.convert
 
     attributes = result[:attributes]
-    assert_http_attribute(attributes, 'http.scheme', 'https')
+    assert_http_attribute(attributes, 'url.scheme', 'https')
   end
 
   def test_extract_scheme_from_http_url
@@ -110,7 +110,7 @@ class HttpConverterTest < Minitest::Test
     result = converter.convert
 
     attributes = result[:attributes]
-    assert_http_attribute(attributes, 'http.scheme', 'http')
+    assert_http_attribute(attributes, 'url.scheme', 'http')
   end
 
   def test_extract_scheme_from_invalid_url
@@ -120,7 +120,7 @@ class HttpConverterTest < Minitest::Test
 
     attributes = result[:attributes]
     # Should not have scheme attribute for invalid URL
-    refute_http_attribute(attributes, 'http.scheme')
+    refute_http_attribute(attributes, 'url.scheme')
   end
 
   def test_extract_scheme_from_nil_url
@@ -130,7 +130,7 @@ class HttpConverterTest < Minitest::Test
 
     attributes = result[:attributes]
     # Should not have scheme attribute for nil URL
-    refute_http_attribute(attributes, 'http.scheme')
+    refute_http_attribute(attributes, 'url.scheme')
   end
 
   def test_http_attributes_with_nil_values_are_not_included
@@ -147,11 +147,11 @@ class HttpConverterTest < Minitest::Test
 
     attributes = result[:attributes]
     # Only method should be present
-    assert_http_attribute(attributes, 'http.method', 'GET')
-    refute_http_attribute(attributes, 'http.url')
-    refute_http_attribute(attributes, 'http.status_code')
-    refute_http_attribute(attributes, 'http.host')
-    refute_http_attribute(attributes, 'http.target')
+    assert_http_attribute(attributes, 'http.request.method', 'GET')
+    refute_http_attribute(attributes, 'url.full')
+    refute_http_attribute(attributes, 'http.response.status_code')
+    refute_http_attribute(attributes, 'server.address')
+    refute_http_attribute(attributes, 'url.path')
   end
 
   def test_http_status_code_as_integer
@@ -160,7 +160,7 @@ class HttpConverterTest < Minitest::Test
     result = converter.convert
 
     attributes = result[:attributes]
-    assert_equal 404, attributes['http.status_code']
+    assert_equal 404, attributes['http.response.status_code']
   end
 
   def test_http_status_code_as_string
@@ -170,7 +170,7 @@ class HttpConverterTest < Minitest::Test
 
     attributes = result[:attributes]
     # Status should be present (as string or converted to int)
-    assert attributes['http.status_code']
+    assert attributes['http.response.status_code']
   end
 
   def test_user_agent_from_header
@@ -185,7 +185,7 @@ class HttpConverterTest < Minitest::Test
     result = converter.convert
 
     attributes = result[:attributes]
-    assert_http_attribute(attributes, 'http.user_agent', 'Mozilla/5.0')
+    assert_http_attribute(attributes, 'user_agent.original', 'Mozilla/5.0')
   end
 
   def test_user_agent_not_present_when_header_missing
@@ -194,7 +194,7 @@ class HttpConverterTest < Minitest::Test
     result = converter.convert
 
     attributes = result[:attributes]
-    refute_http_attribute(attributes, 'http.user_agent')
+    refute_http_attribute(attributes, 'user_agent.original')
   end
 
   def test_user_agent_not_present_when_header_nil
@@ -203,7 +203,7 @@ class HttpConverterTest < Minitest::Test
     result = converter.convert
 
     attributes = result[:attributes]
-    refute_http_attribute(attributes, 'http.user_agent')
+    refute_http_attribute(attributes, 'user_agent.original')
   end
 
   def test_convert_with_error_span
@@ -222,8 +222,8 @@ class HttpConverterTest < Minitest::Test
 
     # Verify HTTP attributes are still present
     attributes = result[:attributes]
-    assert_http_attribute(attributes, 'http.method', 'GET')
-    assert_http_attribute(attributes, 'http.status_code', 500)
+    assert_http_attribute(attributes, 'http.request.method', 'GET')
+    assert_http_attribute(attributes, 'http.response.status_code', 500)
   end
 
   def test_convert_preserves_base_converter_functionality
@@ -257,14 +257,14 @@ class HttpConverterTest < Minitest::Test
 
     attributes = result[:attributes]
 
-    # Verify semantic convention keys are used
+    # Verify semantic convention keys are used (new conventions)
     expected_keys = [
-      'http.method',
-      'http.url',
-      'http.status_code',
-      'http.host',
-      'http.target',
-      'http.scheme'
+      'http.request.method',
+      'url.full',
+      'http.response.status_code',
+      'server.address',
+      'url.path',
+      'url.scheme'
     ]
 
     expected_keys.each do |key|
@@ -285,9 +285,9 @@ class HttpConverterTest < Minitest::Test
     end
 
     assert_equal 3, results.length
-    assert_http_attribute(results[0][:attributes], 'http.method', 'GET')
-    assert_http_attribute(results[1][:attributes], 'http.method', 'POST')
-    assert_http_attribute(results[2][:attributes], 'http.method', 'DELETE')
+    assert_http_attribute(results[0][:attributes], 'http.request.method', 'GET')
+    assert_http_attribute(results[1][:attributes], 'http.request.method', 'POST')
+    assert_http_attribute(results[2][:attributes], 'http.request.method', 'DELETE')
   end
 
   private

--- a/test/exporter/otlp/messaging_converter_test.rb
+++ b/test/exporter/otlp/messaging_converter_test.rb
@@ -3,11 +3,63 @@
 require 'test_helper'
 require 'instana/exporter/otlp/messaging_converter'
 
-# Stub test file for MessagingConverter
-# TODO: Add comprehensive tests for messaging span conversion
 class MessagingConverterTest < Minitest::Test
-  def test_stub
-    # Placeholder test - implement actual tests when MessagingConverter is fully implemented
-    skip 'MessagingConverter is a stub - tests to be implemented'
+  def test_rabbitmq_publish_conversion
+    span = create_span(:rabbitmq, {
+      rabbitmq: { exchange: 'orders', key: 'order.created', queue: 'order_queue', address: 'rabbitmq.local', sort: 'publish' }
+    })
+    converter = Instana::Exporter::Otlp::MessagingConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    assert_equal 'rabbitmq', attrs['messaging.system']
+    assert_equal 'orders', attrs['messaging.destination.name']
+    assert_equal 'order.created', attrs['messaging.rabbitmq.destination.routing_key']
+    assert_equal 'order_queue', attrs['messaging.rabbitmq.queue']
+    assert_equal 'rabbitmq.local', attrs['server.address']
+    assert_equal 'send', attrs['messaging.operation.type']
+  end
+
+  def test_rabbitmq_consume_conversion
+    span = create_span(:rabbitmq, {
+      rabbitmq: { exchange: 'events', key: 'user.signup', address: 'localhost', sort: 'consume' }
+    })
+    converter = Instana::Exporter::Otlp::MessagingConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    assert_equal 'rabbitmq', attrs['messaging.system']
+    assert_equal 'events', attrs['messaging.destination.name']
+    assert_equal 'user.signup', attrs['messaging.rabbitmq.destination.routing_key']
+    assert_equal 'receive', attrs['messaging.operation.type']
+  end
+
+  def test_rabbitmq_minimal_data
+    span = create_span(:rabbitmq, {
+      rabbitmq: { exchange: 'logs', sort: 'publish' }
+    })
+    converter = Instana::Exporter::Otlp::MessagingConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    assert_equal 'rabbitmq', attrs['messaging.system']
+    assert_equal 'logs', attrs['messaging.destination.name']
+    assert_equal 'send', attrs['messaging.operation.type']
+    assert_nil attrs['messaging.rabbitmq.destination.routing_key']
+    assert_nil attrs['messaging.rabbitmq.queue']
+  end
+
+  def test_missing_rabbitmq_data
+    span = create_span(:rabbitmq, {})
+    converter = Instana::Exporter::Otlp::MessagingConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    assert_empty attrs
+  end
+
+  private
+
+  def create_span(name, data)
+    span = Instana::Span.new(name)
+    span[:data] = data
+    span.close
+    span
   end
 end

--- a/test/exporter/otlp/messaging_converter_test.rb
+++ b/test/exporter/otlp/messaging_converter_test.rb
@@ -6,8 +6,8 @@ require 'instana/exporter/otlp/messaging_converter'
 class MessagingConverterTest < Minitest::Test
   def test_rabbitmq_publish_conversion
     span = create_span(:rabbitmq, {
-      rabbitmq: { exchange: 'orders', key: 'order.created', queue: 'order_queue', address: 'rabbitmq.local', sort: 'publish' }
-    })
+                         rabbitmq: { exchange: 'orders', key: 'order.created', queue: 'order_queue', address: 'rabbitmq.local', sort: 'publish' }
+                       })
     converter = Instana::Exporter::Otlp::MessagingConverter.new(span)
     attrs = converter.send(:convert_attributes)
 
@@ -21,8 +21,8 @@ class MessagingConverterTest < Minitest::Test
 
   def test_rabbitmq_consume_conversion
     span = create_span(:rabbitmq, {
-      rabbitmq: { exchange: 'events', key: 'user.signup', address: 'localhost', sort: 'consume' }
-    })
+                         rabbitmq: { exchange: 'events', key: 'user.signup', address: 'localhost', sort: 'consume' }
+                       })
     converter = Instana::Exporter::Otlp::MessagingConverter.new(span)
     attrs = converter.send(:convert_attributes)
 
@@ -34,8 +34,8 @@ class MessagingConverterTest < Minitest::Test
 
   def test_rabbitmq_minimal_data
     span = create_span(:rabbitmq, {
-      rabbitmq: { exchange: 'logs', sort: 'publish' }
-    })
+                         rabbitmq: { exchange: 'logs', sort: 'publish' }
+                       })
     converter = Instana::Exporter::Otlp::MessagingConverter.new(span)
     attrs = converter.send(:convert_attributes)
 

--- a/test/exporter/otlp/rails_converter_test.rb
+++ b/test/exporter/otlp/rails_converter_test.rb
@@ -1,0 +1,84 @@
+# (c) Copyright IBM Corp. 2026
+
+require 'test_helper'
+require 'instana/exporter/otlp/rails_converter'
+
+class RailsConverterTest < Minitest::Test
+  def test_action_controller_conversion
+    span = create_span('actioncontroller', {
+                         actioncontroller: { controller: 'UsersController', action: 'index' }
+                       })
+    converter = Instana::Exporter::Otlp::RailsConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    assert_equal 'UsersController', attrs['code.namespace']
+    assert_equal 'index', attrs['code.function']
+  end
+
+  def test_action_view_conversion
+    span = create_span('actionview', {
+                         actionview: { name: 'users/index.html.erb' }
+                       })
+    converter = Instana::Exporter::Otlp::RailsConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    assert_equal 'users/index.html.erb', attrs['rails.view.name']
+  end
+
+  def test_render_conversion
+    span = create_span('render', {
+                         render: { type: 'partial', name: '_user.html.erb' }
+                       })
+    converter = Instana::Exporter::Otlp::RailsConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    assert_equal 'partial', attrs['rails.render.type']
+    assert_equal '_user.html.erb', attrs['rails.render.name']
+  end
+
+  def test_action_mailer_conversion
+    span = create_span('mail.actionmailer', {
+                         actionmailer: { class: 'UserMailer', method: 'welcome_email' }
+                       })
+    converter = Instana::Exporter::Otlp::RailsConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    assert_equal 'UserMailer', attrs['code.namespace']
+    assert_equal 'welcome_email', attrs['code.function']
+  end
+
+  def test_action_controller_with_nested_data
+    span = create_span('actioncontroller', {})
+    span[:actioncontroller] = { controller: 'PostsController', action: 'show' }
+    converter = Instana::Exporter::Otlp::RailsConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    assert_equal 'PostsController', attrs['code.namespace']
+    assert_equal 'show', attrs['code.function']
+  end
+
+  def test_missing_data
+    span = create_span('actioncontroller', {})
+    converter = Instana::Exporter::Otlp::RailsConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    assert_empty attrs
+  end
+
+  def test_unknown_span_type
+    span = create_span('unknown', {})
+    converter = Instana::Exporter::Otlp::RailsConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    assert_empty attrs
+  end
+
+  private
+
+  def create_span(name, data)
+    span = Instana::Span.new(name.to_sym)
+    span[:data] = data unless data.empty?
+    span.close
+    span
+  end
+end

--- a/test/exporter/otlp/rpc_converter_test.rb
+++ b/test/exporter/otlp/rpc_converter_test.rb
@@ -6,8 +6,8 @@ require 'instana/exporter/otlp/rpc_converter'
 class RpcConverterTest < Minitest::Test
   def test_grpc_conversion
     span = create_span(:grpc, {
-      rpc: { call: '/package.Service/Method', host: 'grpc.example.com', call_type: 'unary' }
-    })
+                         rpc: { call: '/package.Service/Method', host: 'grpc.example.com', call_type: 'unary' }
+                       })
     converter = Instana::Exporter::Otlp::RpcConverter.new(span)
     attrs = converter.send(:convert_attributes)
 
@@ -20,8 +20,8 @@ class RpcConverterTest < Minitest::Test
 
   def test_grpc_with_peer_address
     span = create_span(:grpc, {
-      rpc: { call: '/test.API/Get', peer: { address: '10.0.0.1' } }
-    })
+                         rpc: { call: '/test.API/Get', peer: { address: '10.0.0.1' } }
+                       })
     converter = Instana::Exporter::Otlp::RpcConverter.new(span)
     attrs = converter.send(:convert_attributes)
 
@@ -30,9 +30,9 @@ class RpcConverterTest < Minitest::Test
 
   def test_actioncable_conversion
     span = create_span(:actioncable, {
-      rpc: { flavor: :actioncable, call: 'ChatChannel#speak', host: 'ws.example.com', call_type: 'action' },
-      service: 'my-app'
-    })
+                         rpc: { flavor: :actioncable, call: 'ChatChannel#speak', host: 'ws.example.com', call_type: 'action' },
+                         service: 'my-app'
+                       })
     converter = Instana::Exporter::Otlp::RpcConverter.new(span)
     attrs = converter.send(:convert_attributes)
 
@@ -47,8 +47,8 @@ class RpcConverterTest < Minitest::Test
 
   def test_actioncable_transmit
     span = create_span(:actioncable, {
-      rpc: { flavor: :actioncable, call: 'NotificationChannel', call_type: 'transmit' }
-    })
+                         rpc: { flavor: :actioncable, call: 'NotificationChannel', call_type: 'transmit' }
+                       })
     converter = Instana::Exporter::Otlp::RpcConverter.new(span)
     attrs = converter.send(:convert_attributes)
 

--- a/test/exporter/otlp/rpc_converter_test.rb
+++ b/test/exporter/otlp/rpc_converter_test.rb
@@ -3,11 +3,86 @@
 require 'test_helper'
 require 'instana/exporter/otlp/rpc_converter'
 
-# Stub test file for RpcConverter
-# TODO: Add comprehensive tests for RPC span conversion
 class RpcConverterTest < Minitest::Test
-  def test_stub
-    # Placeholder test - implement actual tests when RpcConverter is fully implemented
-    skip 'RpcConverter is a stub - tests to be implemented'
+  def test_grpc_conversion
+    span = create_span(:grpc, {
+      rpc: { call: '/package.Service/Method', host: 'grpc.example.com', call_type: 'unary' }
+    })
+    converter = Instana::Exporter::Otlp::RpcConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    assert_equal 'grpc', attrs['rpc.system']
+    assert_equal 'package.Service', attrs['rpc.service']
+    assert_equal 'Method', attrs['rpc.method']
+    assert_equal 'grpc.example.com', attrs['server.address']
+    assert_equal 'unary', attrs['rpc.grpc.call_type']
+  end
+
+  def test_grpc_with_peer_address
+    span = create_span(:grpc, {
+      rpc: { call: '/test.API/Get', peer: { address: '10.0.0.1' } }
+    })
+    converter = Instana::Exporter::Otlp::RpcConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    assert_equal '10.0.0.1', attrs['server.address']
+  end
+
+  def test_actioncable_conversion
+    span = create_span(:actioncable, {
+      rpc: { flavor: :actioncable, call: 'ChatChannel#speak', host: 'ws.example.com', call_type: 'action' },
+      service: 'my-app'
+    })
+    converter = Instana::Exporter::Otlp::RpcConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    assert_equal 'actioncable', attrs['rpc.system']
+    assert_equal 'ChatChannel#speak', attrs['rails.actioncable.channel']
+    assert_equal 'action', attrs['rails.actioncable.call_type']
+    assert_equal 'my-app', attrs['rpc.service']
+    assert_equal 'ChatChannel', attrs['code.namespace']
+    assert_equal 'speak', attrs['code.function']
+    assert_equal 'ws.example.com', attrs['server.address']
+  end
+
+  def test_actioncable_transmit
+    span = create_span(:actioncable, {
+      rpc: { flavor: :actioncable, call: 'NotificationChannel', call_type: 'transmit' }
+    })
+    converter = Instana::Exporter::Otlp::RpcConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    assert_equal 'NotificationChannel', attrs['code.namespace']
+    assert_nil attrs['code.function']
+  end
+
+  def test_parse_grpc_call
+    span = create_span(:grpc, {})
+    converter = Instana::Exporter::Otlp::RpcConverter.new(span)
+
+    service, method = converter.send(:parse_grpc_call, '/pkg.Service/Method')
+    assert_equal 'pkg.Service', service
+    assert_equal 'Method', method
+
+    service, method = converter.send(:parse_grpc_call, 'invalid')
+    assert_nil service
+    assert_nil method
+  end
+
+  def test_missing_rpc_data
+    span = create_span(:grpc, {})
+    converter = Instana::Exporter::Otlp::RpcConverter.new(span)
+    attrs = converter.send(:convert_attributes)
+
+    assert_empty attrs
+  end
+
+  private
+
+  def create_span(name, data)
+    span = Instana::Span.new(name)
+    span[:data] = data
+    span.close
+    span
   end
 end


### PR DESCRIPTION
This PR extends the OTLP exporter infrastructure by implementing specialized span converters for all major instrumentation categories. This enables the Ruby sensor to properly convert Instana spans to OTLP format for various service types including AWS services, background jobs, GraphQL, gRPC, and Rails applications.