### PR TITLE
Otlp exporter config

### DIFF
--- a/lib/instana/backend/host_agent_reporting_observer.rb
+++ b/lib/instana/backend/host_agent_reporting_observer.rb
@@ -24,13 +24,7 @@ module Instana
         @timer_class = timer_class
         @nonce = Time.now
         @processor = processor
-        if ENV["INSTANA_OTLP_ENABLED"]
-          @otlp_exporter = OpenTelemetry::Exporter::OTLP::Exporter.new(
-            endpoint: 'http://localhost:4318/v1/traces',
-            timeout: 5.0, # in seconds
-            compression: 'gzip'
-          )
-        end
+        initialize_otlp_exporter
         # Initialize timers with default 1 second interval
         @metrics_timer = @timer_class.new(execution_interval: 1, run_now: true) { report_metrics_to_backend }
         @traces_timer = @timer_class.new(execution_interval: 1, run_now: true) { report_traces_to_backend }
@@ -103,7 +97,6 @@ module Instana
             converted_spans = spans.map do |span|
               ::Instana::Exporter::Otlp::ConverterFactory.create(span).convert
             end
-            Instana.logger.info(converted_spans)
             result_code = @otlp_exporter.export(converted_spans)
             Instana.logger.debug("using otlp exporter to export result code: #{result_code}")
             success = result_code == OpenTelemetry::SDK::Trace::Export::SUCCESS
@@ -179,6 +172,23 @@ module Instana
       def trigger_rediscovery
         @discovery.swap { nil }
         ::Instana.agent.announce
+      end
+
+      def initialize_otlp_exporter
+        config = ::Instana.config[:otlp]
+        unless config[:enabled]
+          @otlp_exporter = nil
+          return
+        end
+
+        opts = { endpoint: config[:endpoint], timeout: config[:timeout] / 1000.0 }
+        opts[:compression] = config[:compression] if config[:compression]
+        opts[:headers]     = config[:headers] if config[:headers]&.any?
+
+        @otlp_exporter = OpenTelemetry::Exporter::OTLP::Exporter.new(**opts)
+      rescue StandardError => e
+        @logger.error("Failed to initialize OTLP exporter: #{e.message}")
+        @otlp_exporter = nil
       end
     end
   end

--- a/lib/instana/backend/host_agent_reporting_observer.rb
+++ b/lib/instana/backend/host_agent_reporting_observer.rb
@@ -38,6 +38,8 @@ module Instana
         if new_version.nil?
           @metrics_timer&.shutdown
           @traces_timer&.shutdown
+          @otlp_exporter&.shutdown
+          @otlp_exporter = nil
         else
           # Read poll_rate from discovery payload - it's nested under plugin.ruby.poll_rate
           discovery = @discovery.value

--- a/lib/instana/backend/host_agent_reporting_observer.rb
+++ b/lib/instana/backend/host_agent_reporting_observer.rb
@@ -183,7 +183,8 @@ module Instana
           return
         end
 
-        opts = { endpoint: config[:endpoint], timeout: config[:timeout] / 1000.0 }
+        endpoint = resolve_otlp_endpoint(config[:endpoint], config[:config_source])
+        opts = { endpoint: endpoint, timeout: config[:timeout] / 1000.0 }
         opts[:compression] = config[:compression] if config[:compression]
         opts[:headers]     = config[:headers] if config[:headers]&.any?
 
@@ -191,6 +192,23 @@ module Instana
       rescue StandardError => e
         @logger.error("Failed to initialize OTLP exporter: #{e.message}")
         @otlp_exporter = nil
+      end
+
+      # Derive the OTLP endpoint from the discovered agent host when no explicit
+      # endpoint has been configured (config_source == 'default').
+      OTLP_DEFAULT_PORT = 4318
+      OTLP_TRACES_PATH  = '/v1/traces'.freeze
+
+      def resolve_otlp_endpoint(endpoint, config_source)
+        return endpoint unless config_source == 'default'
+
+        # Use the host that was discovered by HostAgentLookup (same host the
+        # metrics/traces client is already talking to) and append the standard
+        # OTLP HTTP port and traces path.
+        agent_host = @client&.host
+        return endpoint unless agent_host
+
+        "http://#{agent_host}:#{OTLP_DEFAULT_PORT}#{OTLP_TRACES_PATH}"
       end
     end
   end

--- a/lib/instana/config.rb
+++ b/lib/instana/config.rb
@@ -5,7 +5,7 @@ require 'yaml'
 
 module Instana
   class Config
-    def initialize(logger: ::Instana.logger, agent_host: ENV['INSTANA_AGENT_HOST'], agent_port: ENV['INSTANA_AGENT_PORT'])
+    def initialize(logger: ::Instana.logger, agent_host: ENV['INSTANA_AGENT_HOST'], agent_port: ENV['INSTANA_AGENT_PORT']) # rubocop:disable Metrics/MethodLength
       @config = {}
       if agent_host
         logger.debug "Using custom agent host location specified in INSTANA_AGENT_HOST (#{ENV['INSTANA_AGENT_HOST']})"
@@ -48,6 +48,20 @@ module Instana
       # @config[:back_trace][:stack_trace_level] = all
       # @config[:back_trace] = { stack_trace_level: nil }
       read_span_stack_config
+
+      # OTLP exporter configuration (default: disabled)
+      @config[:otlp] = {
+        enabled: false,
+        endpoint: 'http://localhost:4318/v1/traces',
+        timeout: 10_000,
+        compression: nil,
+        headers: {},
+        certificate: nil,
+        client_key: nil,
+        client_certificate: nil,
+        config_source: 'default'
+      }
+      read_otlp_config
 
       # By default, collected SQL will be sanitized to remove potentially sensitive bind params such as:
       #   > SELECT  "blocks".* FROM "blocks"  WHERE "blocks"."name" = "Mr. Smith"
@@ -122,6 +136,8 @@ module Instana
 
       # Read stack trace configuration from agent if not already set from YAML or env
       read_span_stack_config_from_agent(tracing_config) if should_read_from_agent?(:back_trace)
+      # Read OTLP configuration from agent if not already set from YAML or env
+      read_otlp_config_from_agent(tracing_config) if should_read_from_agent?(:otlp)
       # Read span filtering configuration from agent
       ::Instana.span_filtering_config&.read_config_from_agent(discovery)
     rescue => e
@@ -217,7 +233,124 @@ module Instana
       }
     end
 
+    # Read OTLP configuration from agent discovery
+    # @param tracing_config [Hash] The tracing configuration from discovery
+    def read_otlp_config_from_agent(tracing_config)
+      otlp_config = tracing_config['otlp']
+      return unless otlp_config.is_a?(Hash)
+
+      @config[:otlp][:enabled]            = truthy?(otlp_config['enabled'])         unless otlp_config['enabled'].nil?
+      @config[:otlp][:endpoint]           = otlp_config['endpoint']                 if otlp_config['endpoint']
+      @config[:otlp][:timeout]            = otlp_config['timeout'].to_i             if otlp_config['timeout']
+      @config[:otlp][:compression]        = otlp_config['compression']              if otlp_config['compression']
+      @config[:otlp][:headers]            = otlp_config['headers']                  if otlp_config['headers'].is_a?(Hash)
+      @config[:otlp][:certificate]        = otlp_config['certificate']              if otlp_config['certificate']
+      @config[:otlp][:client_key]         = otlp_config['client_key']               if otlp_config['client_key']
+      @config[:otlp][:client_certificate] = otlp_config['client_certificate']       if otlp_config['client_certificate']
+      @config[:otlp][:config_source]      = 'agent'
+    end
+
     private
+
+    # Read OTLP configuration — precedence: YAML > env vars > defaults (agent handled separately)
+    def read_otlp_config
+      # Try YAML first
+      yaml_otlp = parse_otlp_config_from_yaml
+      if yaml_otlp
+        @config[:otlp].merge!(yaml_otlp)
+        @config[:otlp][:config_source] = 'yaml'
+        return
+      end
+
+      # Try environment variables
+      env_otlp = parse_otlp_config_from_env
+      if env_otlp
+        @config[:otlp].merge!(env_otlp)
+        @config[:otlp][:config_source] = 'env'
+      end
+      # Otherwise leave defaults ('default' config_source), agent can update later
+    end
+
+    # Parse OTLP config from YAML file at INSTANA_CONFIG_PATH under tracing.otlp
+    # @return [Hash, nil] merged OTLP settings or nil if not found
+    def parse_otlp_config_from_yaml
+      config_path = ENV['INSTANA_CONFIG_PATH']
+      return nil unless config_path && File.exist?(config_path)
+
+      begin
+        yaml_content = YAML.safe_load(File.read(config_path))
+        tracing_config = yaml_content['tracing'] || yaml_content['com.instana.tracing']
+        return nil unless tracing_config
+
+        otlp_yaml = tracing_config['otlp']
+        return nil unless otlp_yaml.is_a?(Hash)
+
+        result = {}
+        result[:enabled]            = truthy?(otlp_yaml['enabled'])            unless otlp_yaml['enabled'].nil?
+        result[:endpoint]           = otlp_yaml['endpoint']                    if otlp_yaml['endpoint']
+        result[:timeout]            = otlp_yaml['timeout'].to_i                if otlp_yaml['timeout']
+        result[:compression]        = otlp_yaml['compression']                 if otlp_yaml['compression']
+        result[:headers]            = otlp_yaml['headers']                     if otlp_yaml['headers'].is_a?(Hash)
+        result[:certificate]        = otlp_yaml['certificate']                 if otlp_yaml['certificate']
+        result[:client_key]         = otlp_yaml['client_key']                  if otlp_yaml['client_key']
+        result[:client_certificate] = otlp_yaml['client_certificate']          if otlp_yaml['client_certificate']
+
+        result.empty? ? nil : result
+      rescue => e
+        ::Instana.logger.warn("Failed to load OTLP configuration from YAML: #{e.message}")
+        nil
+      end
+    end
+
+    # Parse OTLP config from environment variables
+    # @return [Hash, nil] merged OTLP settings or nil if no relevant env vars are set
+    def parse_otlp_config_from_env
+      raw = otlp_env_vars
+      return nil if raw.values.all?(&:nil?)
+
+      result = {}
+      result[:enabled]            = truthy?(raw[:enabled_raw])              unless raw[:enabled_raw].nil?
+      result[:endpoint]           = raw[:endpoint]                          if raw[:endpoint]
+      result[:timeout]            = raw[:timeout_raw].to_i                  if raw[:timeout_raw]
+      result[:compression]        = raw[:compression]                       if raw[:compression]
+      result[:headers]            = parse_otlp_headers(raw[:headers_raw])   if raw[:headers_raw]
+      result[:certificate]        = raw[:certificate]                       if raw[:certificate]
+      result[:client_key]         = raw[:client_key]                        if raw[:client_key]
+      result[:client_certificate] = raw[:client_cert]                       if raw[:client_cert]
+      result
+    end
+
+    # Collect raw OTLP-related environment variable values into a single hash
+    # @return [Hash]
+    def otlp_env_vars
+      {
+        enabled_raw: ENV['INSTANA_TRACING_OTLP_ENABLED'],
+        endpoint: ENV['OTEL_EXPORTER_OTLP_TRACES_ENDPOINT'] || ENV['OTEL_EXPORTER_OTLP_ENDPOINT'],
+        timeout_raw: ENV['OTEL_EXPORTER_OTLP_TIMEOUT'],
+        compression: ENV['OTEL_EXPORTER_OTLP_COMPRESSION'],
+        headers_raw: ENV['OTEL_EXPORTER_OTLP_HEADERS'],
+        certificate: ENV['OTEL_EXPORTER_OTLP_CERTIFICATE'],
+        client_key: ENV['OTEL_EXPORTER_OTLP_CLIENT_KEY'],
+        client_cert: ENV['OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE']
+      }
+    end
+
+    # Parse OTEL_EXPORTER_OTLP_HEADERS value (comma-separated key=value pairs) into a Hash
+    # @param headers_str [String] e.g. "api-key=secret,x-tenant=tenant1"
+    # @return [Hash]
+    def parse_otlp_headers(headers_str)
+      return {} unless headers_str
+
+      headers_str.split(',').each_with_object({}) do |pair, hash|
+        key, value = pair.split('=', 2)
+        hash[key.strip] = value&.strip if key
+      end
+    end
+
+    # Normalise a truthy string value to a boolean
+    def truthy?(value)
+      %w[true 1 yes].include?(value.to_s.downcase)
+    end
 
     # Parse global stack trace configuration from a config hash
     # @param global_config [Hash] The global configuration hash

--- a/lib/instana/config.rb
+++ b/lib/instana/config.rb
@@ -274,7 +274,7 @@ module Instana
     # Parse OTLP config from YAML file at INSTANA_CONFIG_PATH under tracing.otlp
     # @return [Hash, nil] merged OTLP settings or nil if not found
     def parse_otlp_config_from_yaml
-      config_path = ENV['INSTANA_CONFIG_PATH']
+      config_path = ENV.fetch('INSTANA_CONFIG_PATH', nil)
       return nil unless config_path && File.exist?(config_path)
 
       begin
@@ -324,14 +324,14 @@ module Instana
     # @return [Hash]
     def otlp_env_vars
       {
-        enabled_raw: ENV['INSTANA_TRACING_OTLP_ENABLED'],
-        endpoint: ENV['OTEL_EXPORTER_OTLP_TRACES_ENDPOINT'] || ENV['OTEL_EXPORTER_OTLP_ENDPOINT'],
-        timeout_raw: ENV['OTEL_EXPORTER_OTLP_TIMEOUT'],
-        compression: ENV['OTEL_EXPORTER_OTLP_COMPRESSION'],
-        headers_raw: ENV['OTEL_EXPORTER_OTLP_HEADERS'],
-        certificate: ENV['OTEL_EXPORTER_OTLP_CERTIFICATE'],
-        client_key: ENV['OTEL_EXPORTER_OTLP_CLIENT_KEY'],
-        client_cert: ENV['OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE']
+        enabled_raw: ENV.fetch('INSTANA_TRACING_OTLP_ENABLED', nil),
+        endpoint: ENV.fetch('OTEL_EXPORTER_OTLP_TRACES_ENDPOINT', nil) || ENV.fetch('OTEL_EXPORTER_OTLP_ENDPOINT', nil),
+        timeout_raw: ENV.fetch('OTEL_EXPORTER_OTLP_TIMEOUT', nil),
+        compression: ENV.fetch('OTEL_EXPORTER_OTLP_COMPRESSION', nil),
+        headers_raw: ENV.fetch('OTEL_EXPORTER_OTLP_HEADERS', nil),
+        certificate: ENV.fetch('OTEL_EXPORTER_OTLP_CERTIFICATE', nil),
+        client_key: ENV.fetch('OTEL_EXPORTER_OTLP_CLIENT_KEY', nil),
+        client_cert: ENV.fetch('OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE', nil)
       }
     end
 

--- a/test/backend/host_agent_reporting_observer_test.rb
+++ b/test/backend/host_agent_reporting_observer_test.rb
@@ -637,4 +637,26 @@ class HostAgentReportingObserverTest < Minitest::Test # rubocop:disable Metrics/
 
     refute_nil discovery.value, 'Discovery should remain valid with empty span batch'
   end
+
+  def test_otlp_exporter_shutdown_on_agent_disconnect
+    client    = Instana::Backend::RequestClient.new('10.10.10.10', 9292)
+    discovery = Concurrent::Atom.new(nil)
+
+    shutdown_called = false
+    fake_exporter = Object.new
+    fake_exporter.define_singleton_method(:shutdown) { shutdown_called = true }
+
+    with_otlp_config(enabled: true) do
+      OpenTelemetry::Exporter::OTLP::Exporter.stub(:new, fake_exporter) do
+        subject = Instana::Backend::HostAgentReportingObserver.new(client, discovery, timer_class: MockTimer)
+
+        # Simulate agent going away (new_version.nil? branch)
+        subject.update(Time.now, nil, nil)
+
+        assert shutdown_called, 'OTLP exporter should be shut down when agent disconnects'
+        assert_nil subject.instance_variable_get(:@otlp_exporter),
+                   'OTLP exporter reference should be cleared after shutdown'
+      end
+    end
+  end
 end

--- a/test/backend/host_agent_reporting_observer_test.rb
+++ b/test/backend/host_agent_reporting_observer_test.rb
@@ -320,263 +320,321 @@ class HostAgentReportingObserverTest < Minitest::Test # rubocop:disable Metrics/
   end
 
   # ============================================================================
-  # OTLP EXPORT TESTS (INSTANA_OTLP_ENABLED environment variable)
+  # OTLP EXPORT TESTS (driven by ::Instana.config[:otlp])
   # ============================================================================
 
-  def test_otlp_export_enabled_with_env_variable
-    ENV['INSTANA_OTLP_ENABLED'] = 'true'
+  # Helper: stub ::Instana.config[:otlp] for the duration of a block
+  def with_otlp_config(overrides = {})
+    base = {
+      enabled: true,
+      endpoint: 'http://localhost:4318/v1/traces',
+      timeout: 5_000,
+      compression: nil,
+      headers: {}
+    }
+    ::Instana.config[:otlp] = base.merge(overrides)
+    yield
+  ensure
+    ::Instana.config[:otlp] = { enabled: false, endpoint: 'http://localhost:4318/v1/traces',
+                                timeout: 10_000, compression: nil, headers: {},
+                                certificate: nil, client_key: nil, client_certificate: nil,
+                                config_source: 'default' }
+  end
 
+  def test_otlp_exporter_initialised_when_config_enabled
+    client    = Instana::Backend::RequestClient.new('10.10.10.10', 9292)
+    discovery = Concurrent::Atom.new(nil)
+
+    fake_exporter = Object.new
+    with_otlp_config(enabled: true) do
+      OpenTelemetry::Exporter::OTLP::Exporter.stub(:new, fake_exporter) do
+        subject = Instana::Backend::HostAgentReportingObserver.new(client, discovery, timer_class: MockTimer)
+        refute_nil subject.instance_variable_get(:@otlp_exporter),
+                   'OTLP exporter should be initialised when config[:otlp][:enabled] is true'
+      end
+    end
+  end
+
+  def test_otlp_exporter_nil_when_config_disabled
+    client    = Instana::Backend::RequestClient.new('10.10.10.10', 9292)
+    discovery = Concurrent::Atom.new(nil)
+
+    with_otlp_config(enabled: false) do
+      subject = Instana::Backend::HostAgentReportingObserver.new(client, discovery, timer_class: MockTimer)
+      assert_nil subject.instance_variable_get(:@otlp_exporter),
+                 'OTLP exporter should be nil when config[:otlp][:enabled] is false'
+    end
+  end
+
+  def test_otlp_exporter_construction_error_is_rescued
+    client    = Instana::Backend::RequestClient.new('10.10.10.10', 9292)
+    discovery = Concurrent::Atom.new(nil)
+    log_lines = []
+    logger    = Logger.new(StringIO.new).tap { |l| l.define_singleton_method(:error) { |msg| log_lines << msg } }
+
+    with_otlp_config(enabled: true) do
+      OpenTelemetry::Exporter::OTLP::Exporter.stub(:new, ->(**_) { raise StandardError, 'boom' }) do
+        subject = Instana::Backend::HostAgentReportingObserver.new(client, discovery,
+                                                                   logger: logger,
+                                                                   timer_class: MockTimer)
+        assert_nil subject.instance_variable_get(:@otlp_exporter),
+                   'Exporter should be nil when construction raises'
+        assert log_lines.any? { |l| l.include?('boom') },
+               'Error should be logged'
+      end
+    end
+  end
+
+  def test_otlp_exporter_timeout_converted_to_seconds
+    client    = Instana::Backend::RequestClient.new('10.10.10.10', 9292)
+    discovery = Concurrent::Atom.new(nil)
+    received_opts = nil
+
+    with_otlp_config(enabled: true, timeout: 8_000) do
+      capture = lambda { |** opts|
+        received_opts = opts
+        Minitest::Mock.new
+      }
+      OpenTelemetry::Exporter::OTLP::Exporter.stub(:new, capture) do
+        Instana::Backend::HostAgentReportingObserver.new(client, discovery, timer_class: MockTimer)
+      end
+    end
+
+    assert_in_delta 8.0, received_opts[:timeout], 0.001,
+                    'Timeout should be converted from ms to seconds'
+  end
+
+  def test_otlp_exporter_passes_compression_when_set
+    client    = Instana::Backend::RequestClient.new('10.10.10.10', 9292)
+    discovery = Concurrent::Atom.new(nil)
+    received_opts = nil
+
+    with_otlp_config(enabled: true, compression: 'gzip') do
+      capture = lambda { |**opts|
+        received_opts = opts
+        Minitest::Mock.new
+      }
+      OpenTelemetry::Exporter::OTLP::Exporter.stub(:new, capture) do
+        Instana::Backend::HostAgentReportingObserver.new(client, discovery, timer_class: MockTimer)
+      end
+    end
+
+    assert_equal 'gzip', received_opts[:compression]
+  end
+
+  def test_otlp_exporter_passes_headers_when_present
+    client    = Instana::Backend::RequestClient.new('10.10.10.10', 9292)
+    discovery = Concurrent::Atom.new(nil)
+    received_opts = nil
+
+    with_otlp_config(enabled: true, headers: { 'x-api-key' => 'secret' }) do
+      capture = lambda { |**opts|
+        received_opts = opts
+        Minitest::Mock.new
+      }
+      OpenTelemetry::Exporter::OTLP::Exporter.stub(:new, capture) do
+        Instana::Backend::HostAgentReportingObserver.new(client, discovery, timer_class: MockTimer)
+      end
+    end
+
+    assert_equal({ 'x-api-key' => 'secret' }, received_opts[:headers])
+  end
+
+  def test_otlp_export_enabled_exports_spans
     stub_request(:post, "http://10.10.10.10:9292/com.instana.plugin.ruby.1234")
       .to_return(status: 200)
 
-    client = Instana::Backend::RequestClient.new('10.10.10.10', 9292)
+    client    = Instana::Backend::RequestClient.new('10.10.10.10', 9292)
     discovery = Concurrent::Atom.new({'pid' => 1234})
 
     exported_spans = nil
-    otlp_exporter = Minitest::Mock.new
+    otlp_exporter  = Minitest::Mock.new
     otlp_exporter.expect(:export, OpenTelemetry::SDK::Trace::Export::SUCCESS) do |spans|
       exported_spans = spans
       OpenTelemetry::SDK::Trace::Export::SUCCESS
     end
 
     processor = Class.new do
-      def send
-        yield([{n: 'test', t: '1234', s: '5678'}])
-      end
+      def send = yield([{n: 'test', t: '1234', s: '5678'}])
     end.new
 
-    OpenTelemetry::Exporter::OTLP::Exporter.stub(:new, otlp_exporter) do
-      subject = Instana::Backend::HostAgentReportingObserver.new(client, discovery, timer_class: MockTimer, processor: processor)
-
-      subject.traces_timer.block.call
+    with_otlp_config(enabled: true) do
+      OpenTelemetry::Exporter::OTLP::Exporter.stub(:new, otlp_exporter) do
+        subject = Instana::Backend::HostAgentReportingObserver.new(client, discovery,
+                                                                   timer_class: MockTimer,
+                                                                   processor: processor)
+        subject.traces_timer.block.call
+      end
     end
 
-    refute_nil exported_spans, "OTLP exporter should have received spans"
-    assert exported_spans.is_a?(Array), "Exported spans should be an array"
-    assert_equal 1, exported_spans.length, "Should export 1 converted span"
+    refute_nil exported_spans, 'OTLP exporter should have received spans'
+    assert     exported_spans.is_a?(Array)
+    assert_equal 1, exported_spans.length
     otlp_exporter.verify
-    refute_nil discovery.value, "Discovery should remain valid after successful export"
-  ensure
-    ENV.delete('INSTANA_OTLP_ENABLED')
+    refute_nil discovery.value, 'Discovery should remain valid after successful export'
   end
 
-  def test_otlp_export_disabled_without_env_variable
-    ENV.delete('INSTANA_OTLP_ENABLED')
-
+  def test_otlp_export_disabled_uses_native_reporting
     stub_request(:post, "http://10.10.10.10:9292/com.instana.plugin.ruby.1234")
       .to_return(status: 200)
-
     stub_request(:post, "http://10.10.10.10:9292/com.instana.plugin.ruby/traces.1234")
       .to_return(status: 200)
 
-    client = Instana::Backend::RequestClient.new('10.10.10.10', 9292)
+    client    = Instana::Backend::RequestClient.new('10.10.10.10', 9292)
     discovery = Concurrent::Atom.new({'pid' => 1234})
 
     processor = Class.new do
-      def send
-        yield([{n: 'test'}])
-      end
+      def send = yield([{n: 'test'}])
     end.new
 
-    # Should not create OTLP exporter
-    subject = Instana::Backend::HostAgentReportingObserver.new(client, discovery, timer_class: MockTimer, processor: processor)
+    with_otlp_config(enabled: false) do
+      subject = Instana::Backend::HostAgentReportingObserver.new(client, discovery,
+                                                                 timer_class: MockTimer,
+                                                                 processor: processor)
+      assert_nil subject.instance_variable_get(:@otlp_exporter),
+                 'OTLP exporter should not be initialised when disabled'
+      subject.traces_timer.block.call
+    end
 
-    assert_nil subject.instance_variable_get(:@otlp_exporter), "OTLP exporter should not be initialized without env variable"
-
-    subject.traces_timer.block.call
-    refute_nil discovery.value, "Discovery should remain valid"
+    refute_nil discovery.value, 'Discovery should remain valid'
   end
 
   def test_otlp_export_converts_spans_correctly
-    ENV['INSTANA_OTLP_ENABLED'] = 'true'
-
     stub_request(:post, "http://10.10.10.10:9292/com.instana.plugin.ruby.1234")
       .to_return(status: 200)
 
-    client = Instana::Backend::RequestClient.new('10.10.10.10', 9292)
+    client    = Instana::Backend::RequestClient.new('10.10.10.10', 9292)
     discovery = Concurrent::Atom.new({'pid' => 1234})
 
     test_span = {
-      n: 'rack',
-      t: '1234567890abcdef',
-      s: 'fedcba0987654321',
-      ts: Time.now.to_i * 1000,
-      d: 100,
-      k: 1,
-      data: {
-        http: {
-          method: 'GET',
-          url: 'http://example.com/test',
-          status: 200
-        }
-      }
+      n: 'rack', t: '1234567890abcdef', s: 'fedcba0987654321',
+      ts: Time.now.to_i * 1000, d: 100, k: 1,
+      data: { http: { method: 'GET', url: 'http://example.com/test', status: 200 } }
     }
 
     exported_spans = nil
-    otlp_exporter = Minitest::Mock.new
+    otlp_exporter  = Minitest::Mock.new
     otlp_exporter.expect(:export, OpenTelemetry::SDK::Trace::Export::SUCCESS) do |spans|
       exported_spans = spans
       OpenTelemetry::SDK::Trace::Export::SUCCESS
     end
 
     processor = Class.new do
-      attr_reader :test_span
-
-      def initialize(span)
-        @test_span = span
-      end
-
-      def send
-        yield([@test_span])
-      end
+      def initialize(span) = @span = span
+      def send = yield([@span])
     end.new(test_span)
 
-    OpenTelemetry::Exporter::OTLP::Exporter.stub(:new, otlp_exporter) do
-      subject = Instana::Backend::HostAgentReportingObserver.new(client, discovery, timer_class: MockTimer, processor: processor)
-
-      subject.traces_timer.block.call
+    with_otlp_config(enabled: true) do
+      OpenTelemetry::Exporter::OTLP::Exporter.stub(:new, otlp_exporter) do
+        subject = Instana::Backend::HostAgentReportingObserver.new(client, discovery,
+                                                                   timer_class: MockTimer,
+                                                                   processor: processor)
+        subject.traces_timer.block.call
+      end
     end
 
-    refute_nil exported_spans, "Should export converted spans"
-    assert exported_spans.is_a?(Array), "Exported spans should be an array"
-    assert_equal 1, exported_spans.length, "Should export 1 converted span"
-
-    # The converter returns OpenTelemetry::SDK::Trace::SpanData
-    # Just verify we got a converted span object
-    refute_nil exported_spans.first, "Converted span should not be nil"
-
+    refute_nil exported_spans
+    assert_equal 1, exported_spans.length
+    refute_nil exported_spans.first
     otlp_exporter.verify
-  ensure
-    ENV.delete('INSTANA_OTLP_ENABLED')
   end
 
   def test_otlp_export_failure_triggers_rediscovery
-    ENV['INSTANA_OTLP_ENABLED'] = 'true'
-
     stub_request(:post, "http://10.10.10.10:9292/com.instana.plugin.ruby.1234")
       .to_return(status: 200)
-
-    stub_request(:get, "http://127.0.0.1:42699/")
+    stub_request(:get,  "http://127.0.0.1:42699/")
       .to_return(status: 200)
-    stub_request(:put, "http://127.0.0.1:42699/com.instana.plugin.ruby.discovery")
+    stub_request(:put,  "http://127.0.0.1:42699/com.instana.plugin.ruby.discovery")
       .to_return(status: 200, body: '{"pid": 1234}')
     stub_request(:head, "http://127.0.0.1:42699/com.instana.plugin.ruby.1234")
       .to_return(status: 200)
 
-    client = Instana::Backend::RequestClient.new('10.10.10.10', 9292)
+    client    = Instana::Backend::RequestClient.new('10.10.10.10', 9292)
     discovery = Concurrent::Atom.new({'pid' => 1234})
 
     otlp_exporter = Minitest::Mock.new
-    # Return FAILURE status code
     otlp_exporter.expect(:export, OpenTelemetry::SDK::Trace::Export::FAILURE) do |_spans|
       OpenTelemetry::SDK::Trace::Export::FAILURE
     end
 
     processor = Class.new do
-      def send
-        yield([{n: 'test'}])
-      end
+      def send = yield([{n: 'test'}])
     end.new
 
-    OpenTelemetry::Exporter::OTLP::Exporter.stub(:new, otlp_exporter) do
-      subject = Instana::Backend::HostAgentReportingObserver.new(client, discovery, timer_class: MockTimer, processor: processor)
-
-      subject.traces_timer.block.call
+    with_otlp_config(enabled: true) do
+      OpenTelemetry::Exporter::OTLP::Exporter.stub(:new, otlp_exporter) do
+        subject = Instana::Backend::HostAgentReportingObserver.new(client, discovery,
+                                                                   timer_class: MockTimer,
+                                                                   processor: processor)
+        subject.traces_timer.block.call
+      end
     end
 
     otlp_exporter.verify
-    assert_nil discovery.value, "Discovery should be reset after export failure"
-  ensure
-    ENV.delete('INSTANA_OTLP_ENABLED')
+    assert_nil discovery.value, 'Discovery should be reset after export failure'
   end
 
   def test_otlp_export_with_multiple_spans
-    ENV['INSTANA_OTLP_ENABLED'] = 'true'
-
     stub_request(:post, "http://10.10.10.10:9292/com.instana.plugin.ruby.1234")
       .to_return(status: 200)
 
-    client = Instana::Backend::RequestClient.new('10.10.10.10', 9292)
+    client    = Instana::Backend::RequestClient.new('10.10.10.10', 9292)
     discovery = Concurrent::Atom.new({'pid' => 1234})
 
     test_spans = [
-      {n: 'rack', t: '1111', s: '2222'},
+      {n: 'rack',        t: '1111', s: '2222'},
       {n: 'activerecord', t: '1111', s: '3333', p: '2222'},
-      {n: 'redis', t: '1111', s: '4444', p: '2222'}
+      {n: 'redis',        t: '1111', s: '4444', p: '2222'}
     ]
 
     exported_spans = nil
-    otlp_exporter = Minitest::Mock.new
+    otlp_exporter  = Minitest::Mock.new
     otlp_exporter.expect(:export, OpenTelemetry::SDK::Trace::Export::SUCCESS) do |spans|
       exported_spans = spans
       OpenTelemetry::SDK::Trace::Export::SUCCESS
     end
 
     processor = Class.new do
-      attr_reader :test_spans
-
-      def initialize(spans)
-        @test_spans = spans
-      end
-
-      def send
-        yield(@test_spans)
-      end
+      def initialize(spans) = @spans = spans
+      def send = yield(@spans)
     end.new(test_spans)
 
-    OpenTelemetry::Exporter::OTLP::Exporter.stub(:new, otlp_exporter) do
-      subject = Instana::Backend::HostAgentReportingObserver.new(client, discovery, timer_class: MockTimer, processor: processor)
-
-      subject.traces_timer.block.call
+    with_otlp_config(enabled: true) do
+      OpenTelemetry::Exporter::OTLP::Exporter.stub(:new, otlp_exporter) do
+        subject = Instana::Backend::HostAgentReportingObserver.new(client, discovery,
+                                                                   timer_class: MockTimer,
+                                                                   processor: processor)
+        subject.traces_timer.block.call
+      end
     end
 
-    refute_nil exported_spans, "Should export converted spans"
-    assert_equal 3, exported_spans.length, "Should export all 3 converted spans"
+    refute_nil exported_spans
+    assert_equal 3, exported_spans.length
     otlp_exporter.verify
-  ensure
-    ENV.delete('INSTANA_OTLP_ENABLED')
-  end
-
-  def test_otlp_exporter_initialization_with_env_variable
-    ENV['INSTANA_OTLP_ENABLED'] = 'true'
-
-    client = Instana::Backend::RequestClient.new('10.10.10.10', 9292)
-    discovery = Concurrent::Atom.new(nil)
-
-    subject = Instana::Backend::HostAgentReportingObserver.new(client, discovery, timer_class: MockTimer)
-
-    refute_nil subject.instance_variable_get(:@otlp_exporter), "OTLP exporter should be initialized when env variable is set"
-  ensure
-    ENV.delete('INSTANA_OTLP_ENABLED')
   end
 
   def test_otlp_export_handles_empty_span_batch
-    ENV['INSTANA_OTLP_ENABLED'] = 'true'
-
     stub_request(:post, "http://10.10.10.10:9292/com.instana.plugin.ruby.1234")
       .to_return(status: 200)
 
-    client = Instana::Backend::RequestClient.new('10.10.10.10', 9292)
+    client    = Instana::Backend::RequestClient.new('10.10.10.10', 9292)
     discovery = Concurrent::Atom.new({'pid' => 1234})
 
-    otlp_exporter = Minitest::Mock.new
-    # Should not be called for empty batch
+    otlp_exporter = Minitest::Mock.new # export should never be called
 
     processor = Class.new do
-      def send
-        yield([])
-      end
+      def send = yield([])
     end.new
 
-    OpenTelemetry::Exporter::OTLP::Exporter.stub(:new, otlp_exporter) do
-      subject = Instana::Backend::HostAgentReportingObserver.new(client, discovery, timer_class: MockTimer, processor: processor)
-
-      subject.traces_timer.block.call
+    with_otlp_config(enabled: true) do
+      OpenTelemetry::Exporter::OTLP::Exporter.stub(:new, otlp_exporter) do
+        subject = Instana::Backend::HostAgentReportingObserver.new(client, discovery,
+                                                                   timer_class: MockTimer,
+                                                                   processor: processor)
+        subject.traces_timer.block.call
+      end
     end
 
-    # Discovery should remain valid even with empty batch
-    refute_nil discovery.value, "Discovery should remain valid with empty span batch"
-  ensure
-    ENV.delete('INSTANA_OTLP_ENABLED')
+    refute_nil discovery.value, 'Discovery should remain valid with empty span batch'
   end
 end

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -706,3 +706,357 @@ class ConfigTest < Minitest::Test # rubocop:disable Metrics/ClassLength
     ENV.delete('INSTANA_CONFIG_PATH')
   end
 end
+
+# ============================================================================
+# OTLP configuration tests
+# ============================================================================
+
+class OtlpConfigTest < Minitest::Test
+  OTLP_ENV_VARS = %w[
+    INSTANA_TRACING_OTLP_ENABLED
+    OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+    OTEL_EXPORTER_OTLP_ENDPOINT
+    OTEL_EXPORTER_OTLP_TIMEOUT
+    OTEL_EXPORTER_OTLP_COMPRESSION
+    OTEL_EXPORTER_OTLP_HEADERS
+    OTEL_EXPORTER_OTLP_CERTIFICATE
+    OTEL_EXPORTER_OTLP_CLIENT_KEY
+    OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE
+    INSTANA_CONFIG_PATH
+  ].freeze
+
+  def setup
+    OTLP_ENV_VARS.each { |k| ENV.delete(k) }
+  end
+
+  def teardown
+    OTLP_ENV_VARS.each { |k| ENV.delete(k) }
+    File.unlink('test_otlp_config.yaml') if File.exist?('test_otlp_config.yaml')
+  end
+
+  # ── defaults ───────────────────────────────────────────────────────────────
+
+  def test_otlp_defaults_when_no_env_or_yaml
+    subject = Instana::Config.new(logger: Logger.new('/dev/null'))
+
+    otlp = subject[:otlp]
+    refute_nil otlp, 'config[:otlp] should always be populated'
+    assert_equal false, otlp[:enabled]
+    assert_equal 'http://localhost:4318/v1/traces', otlp[:endpoint]
+    assert_equal 10_000, otlp[:timeout]
+    assert_nil otlp[:compression]
+    assert_equal({}, otlp[:headers])
+    assert_nil otlp[:certificate]
+    assert_nil otlp[:client_key]
+    assert_nil otlp[:client_certificate]
+    assert_equal 'default', otlp[:config_source]
+  end
+
+  # ── INSTANA_TRACING_OTLP_ENABLED truthy variants ──────────────────────────
+
+  def test_enable_flag_true_string
+    ENV['INSTANA_TRACING_OTLP_ENABLED'] = 'true'
+
+    subject = Instana::Config.new(logger: Logger.new('/dev/null'))
+
+    assert_equal true,  subject[:otlp][:enabled]
+    assert_equal 'env', subject[:otlp][:config_source]
+  end
+
+  def test_enable_flag_one_string
+    ENV['INSTANA_TRACING_OTLP_ENABLED'] = '1'
+
+    subject = Instana::Config.new(logger: Logger.new('/dev/null'))
+
+    assert_equal true, subject[:otlp][:enabled]
+  end
+
+  def test_enable_flag_yes_string
+    ENV['INSTANA_TRACING_OTLP_ENABLED'] = 'yes'
+
+    subject = Instana::Config.new(logger: Logger.new('/dev/null'))
+
+    assert_equal true, subject[:otlp][:enabled]
+  end
+
+  def test_enable_flag_yes_case_insensitive
+    ENV['INSTANA_TRACING_OTLP_ENABLED'] = 'YES'
+
+    subject = Instana::Config.new(logger: Logger.new('/dev/null'))
+
+    assert_equal true, subject[:otlp][:enabled]
+  end
+
+  def test_enable_flag_false_leaves_disabled
+    ENV['INSTANA_TRACING_OTLP_ENABLED'] = 'false'
+
+    subject = Instana::Config.new(logger: Logger.new('/dev/null'))
+
+    assert_equal false, subject[:otlp][:enabled]
+    assert_equal 'env', subject[:otlp][:config_source]
+  end
+
+  # ── endpoint precedence ────────────────────────────────────────────────────
+
+  def test_traces_endpoint_takes_precedence_over_base_endpoint
+    ENV['OTEL_EXPORTER_OTLP_TRACES_ENDPOINT'] = 'http://traces.example.com/v1/traces'
+    ENV['OTEL_EXPORTER_OTLP_ENDPOINT']        = 'http://base.example.com'
+
+    subject = Instana::Config.new(logger: Logger.new('/dev/null'))
+
+    assert_equal 'http://traces.example.com/v1/traces', subject[:otlp][:endpoint]
+  end
+
+  def test_base_endpoint_used_when_no_traces_endpoint
+    ENV['OTEL_EXPORTER_OTLP_ENDPOINT'] = 'http://base.example.com'
+
+    subject = Instana::Config.new(logger: Logger.new('/dev/null'))
+
+    assert_equal 'http://base.example.com', subject[:otlp][:endpoint]
+  end
+
+  # ── timeout ────────────────────────────────────────────────────────────────
+
+  def test_timeout_stored_as_integer_milliseconds
+    ENV['OTEL_EXPORTER_OTLP_TIMEOUT'] = '30000'
+
+    subject = Instana::Config.new(logger: Logger.new('/dev/null'))
+
+    assert_equal 30_000, subject[:otlp][:timeout]
+    assert_instance_of Integer, subject[:otlp][:timeout]
+  end
+
+  # ── compression ───────────────────────────────────────────────────────────
+
+  def test_compression_from_env
+    ENV['OTEL_EXPORTER_OTLP_COMPRESSION'] = 'gzip'
+
+    subject = Instana::Config.new(logger: Logger.new('/dev/null'))
+
+    assert_equal 'gzip', subject[:otlp][:compression]
+  end
+
+  # ── headers ───────────────────────────────────────────────────────────────
+
+  def test_headers_parsed_from_env_into_hash
+    ENV['OTEL_EXPORTER_OTLP_HEADERS'] = 'api-key=secret,x-tenant=tenant1'
+
+    subject = Instana::Config.new(logger: Logger.new('/dev/null'))
+
+    assert_equal({ 'api-key' => 'secret', 'x-tenant' => 'tenant1' }, subject[:otlp][:headers])
+  end
+
+  def test_single_header_parsed_correctly
+    ENV['OTEL_EXPORTER_OTLP_HEADERS'] = 'authorization=Bearer token123'
+
+    subject = Instana::Config.new(logger: Logger.new('/dev/null'))
+
+    assert_equal({ 'authorization' => 'Bearer token123' }, subject[:otlp][:headers])
+  end
+
+  # ── TLS fields ────────────────────────────────────────────────────────────
+
+  def test_tls_fields_from_env
+    ENV['OTEL_EXPORTER_OTLP_CERTIFICATE']        = '/etc/certs/ca.pem'
+    ENV['OTEL_EXPORTER_OTLP_CLIENT_KEY']         = '/etc/certs/client.key'
+    ENV['OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE'] = '/etc/certs/client.crt'
+
+    subject = Instana::Config.new(logger: Logger.new('/dev/null'))
+
+    assert_equal '/etc/certs/ca.pem',     subject[:otlp][:certificate]
+    assert_equal '/etc/certs/client.key', subject[:otlp][:client_key]
+    assert_equal '/etc/certs/client.crt', subject[:otlp][:client_certificate]
+  end
+
+  # ── YAML configuration ────────────────────────────────────────────────────
+
+  def test_yaml_populates_otlp_config
+    yaml_content = <<~YAML
+      tracing:
+        otlp:
+          enabled: true
+          endpoint: "http://otlp.example.com/v1/traces"
+          timeout: 5000
+          compression: gzip
+    YAML
+
+    File.write('test_otlp_config.yaml', yaml_content)
+    ENV['INSTANA_CONFIG_PATH'] = 'test_otlp_config.yaml'
+
+    subject = Instana::Config.new(logger: Logger.new('/dev/null'))
+
+    assert_equal true, subject[:otlp][:enabled]
+    assert_equal 'http://otlp.example.com/v1/traces', subject[:otlp][:endpoint]
+    assert_equal 5000,                                  subject[:otlp][:timeout]
+    assert_equal 'gzip',                                subject[:otlp][:compression]
+    assert_equal 'yaml',                                subject[:otlp][:config_source]
+  end
+
+  def test_yaml_headers_as_hash
+    yaml_content = <<~YAML
+      tracing:
+        otlp:
+          enabled: true
+          headers:
+            x-api-key: mysecret
+            x-tenant: acme
+    YAML
+
+    File.write('test_otlp_config.yaml', yaml_content)
+    ENV['INSTANA_CONFIG_PATH'] = 'test_otlp_config.yaml'
+
+    subject = Instana::Config.new(logger: Logger.new('/dev/null'))
+
+    assert_equal({ 'x-api-key' => 'mysecret', 'x-tenant' => 'acme' }, subject[:otlp][:headers])
+  end
+
+  def test_yaml_takes_precedence_over_env
+    yaml_content = <<~YAML
+      tracing:
+        otlp:
+          enabled: true
+          endpoint: "http://from-yaml.example.com/v1/traces"
+          timeout: 5000
+    YAML
+
+    File.write('test_otlp_config.yaml', yaml_content)
+    ENV['INSTANA_CONFIG_PATH']                 = 'test_otlp_config.yaml'
+    ENV['INSTANA_TRACING_OTLP_ENABLED']        = 'false'
+    ENV['OTEL_EXPORTER_OTLP_TRACES_ENDPOINT'] = 'http://from-env.example.com/v1/traces'
+
+    subject = Instana::Config.new(logger: Logger.new('/dev/null'))
+
+    assert_equal true, subject[:otlp][:enabled]
+    assert_equal 'http://from-yaml.example.com/v1/traces', subject[:otlp][:endpoint]
+    assert_equal 'yaml', subject[:otlp][:config_source]
+  end
+
+  def test_yaml_without_otlp_section_leaves_defaults
+    yaml_content = <<~YAML
+      tracing:
+        global:
+          stack-trace: error
+    YAML
+
+    File.write('test_otlp_config.yaml', yaml_content)
+    ENV['INSTANA_CONFIG_PATH'] = 'test_otlp_config.yaml'
+
+    subject = Instana::Config.new(logger: Logger.new('/dev/null'))
+
+    assert_equal false,     subject[:otlp][:enabled]
+    assert_equal 'default', subject[:otlp][:config_source]
+  end
+
+  # ── agent discovery ───────────────────────────────────────────────────────
+
+  def test_agent_discovery_sets_otlp_config_when_source_is_default
+    subject = Instana::Config.new(logger: Logger.new('/dev/null'))
+    assert_equal 'default', subject[:otlp][:config_source]
+
+    discovery = {
+      'tracing' => {
+        'otlp' => {
+          'enabled' => 'true',
+          'endpoint' => 'http://agent.example.com/v1/traces',
+          'timeout' => 8000
+        }
+      }
+    }
+    subject.read_config_from_agent(discovery)
+
+    assert_equal true, subject[:otlp][:enabled]
+    assert_equal 'http://agent.example.com/v1/traces', subject[:otlp][:endpoint]
+    assert_equal 8000,                                    subject[:otlp][:timeout]
+    assert_equal 'agent',                                 subject[:otlp][:config_source]
+  end
+
+  def test_agent_discovery_does_not_override_env_config
+    ENV['INSTANA_TRACING_OTLP_ENABLED'] = 'true'
+    ENV['OTEL_EXPORTER_OTLP_TRACES_ENDPOINT'] = 'http://from-env.example.com/v1/traces'
+
+    subject = Instana::Config.new(logger: Logger.new('/dev/null'))
+    assert_equal 'env', subject[:otlp][:config_source]
+
+    discovery = {
+      'tracing' => {
+        'otlp' => {
+          'enabled' => 'false',
+          'endpoint' => 'http://agent.example.com/v1/traces'
+        }
+      }
+    }
+    subject.read_config_from_agent(discovery)
+
+    # env values must be preserved
+    assert_equal true, subject[:otlp][:enabled]
+    assert_equal 'http://from-env.example.com/v1/traces', subject[:otlp][:endpoint]
+    assert_equal 'env', subject[:otlp][:config_source]
+  end
+
+  def test_agent_discovery_does_not_override_yaml_config
+    yaml_content = <<~YAML
+      tracing:
+        otlp:
+          enabled: true
+          endpoint: "http://from-yaml.example.com/v1/traces"
+    YAML
+
+    File.write('test_otlp_config.yaml', yaml_content)
+    ENV['INSTANA_CONFIG_PATH'] = 'test_otlp_config.yaml'
+
+    subject = Instana::Config.new(logger: Logger.new('/dev/null'))
+    assert_equal 'yaml', subject[:otlp][:config_source]
+
+    discovery = {
+      'tracing' => {
+        'otlp' => {
+          'enabled' => 'false',
+          'endpoint' => 'http://agent.example.com/v1/traces'
+        }
+      }
+    }
+    subject.read_config_from_agent(discovery)
+
+    assert_equal true, subject[:otlp][:enabled]
+    assert_equal 'http://from-yaml.example.com/v1/traces', subject[:otlp][:endpoint]
+    assert_equal 'yaml', subject[:otlp][:config_source]
+  end
+
+  def test_agent_discovery_without_otlp_key_is_ignored
+    subject = Instana::Config.new(logger: Logger.new('/dev/null'))
+
+    discovery = { 'tracing' => { 'global' => { 'stack-trace' => 'all' } } }
+    subject.read_config_from_agent(discovery)
+
+    assert_equal false,     subject[:otlp][:enabled]
+    assert_equal 'default', subject[:otlp][:config_source]
+  end
+
+  # ── should_read_from_agent? guard ────────────────────────────────────────
+
+  def test_should_read_from_agent_returns_true_for_default_otlp
+    subject = Instana::Config.new(logger: Logger.new('/dev/null'))
+    assert subject.send(:should_read_from_agent?, :otlp)
+  end
+
+  def test_should_read_from_agent_returns_false_after_env_config
+    ENV['INSTANA_TRACING_OTLP_ENABLED'] = 'true'
+
+    subject = Instana::Config.new(logger: Logger.new('/dev/null'))
+    refute subject.send(:should_read_from_agent?, :otlp)
+  end
+
+  def test_should_read_from_agent_returns_false_after_yaml_config
+    yaml_content = <<~YAML
+      tracing:
+        otlp:
+          enabled: true
+    YAML
+
+    File.write('test_otlp_config.yaml', yaml_content)
+    ENV['INSTANA_CONFIG_PATH'] = 'test_otlp_config.yaml'
+
+    subject = Instana::Config.new(logger: Logger.new('/dev/null'))
+    refute subject.send(:should_read_from_agent?, :otlp)
+  end
+end


### PR DESCRIPTION
Replaces the hardcoded INSTANA_OTLP_ENABLED env-var check with a proper config-driven setup. OTLP settings are now resolved through the standard Instana config system with precedence: YAML → env vars → agent discovery → defaults.

Change
Config - add :otlp config block (default: disabled); support YAML, env var, and agent-push config sources
HostAgentReportingObserver — replace inline exporter construction with initialize_otlp_exporter driven by ::Instana.config[:otlp]; remove stray debug log
Tests - add config_test.rb and expand observer tests to cover OTLP init paths