### PR TITLE
Translate span names to otlp format

### DIFF
--- a/lib/instana/exporter/otlp/aws_converter.rb
+++ b/lib/instana/exporter/otlp/aws_converter.rb
@@ -12,6 +12,51 @@ module Instana
     module Otlp
       # Converter for AWS SDK spans (SQS, SNS, DynamoDB) to OTLP format
       class AwsConverter < BaseConverter
+        # Build OTel-compliant span name for AWS SDK spans
+        #
+        # Formulas per SPAN_NAME_PATTERNS.txt Section 6:
+        #   SQS send/publish  → "{queue} publish"
+        #   SQS receive/delete → "{queue} receive"
+        #   SNS               → "{topic} publish"
+        #   DynamoDB          → "DynamoDB.{op}"      e.g. "DynamoDB.PutItem"
+        #   S3                → "S3.{op}"            e.g. "S3.PutObject"
+        #   Lambda invoke     → "Lambda.{function}"
+        #
+        # @return [String] The span name
+        def span_name
+          data = span[:data] || {}
+
+          if (sqs = data[:sqs])
+            queue = sqs[:queue].to_s.strip
+            operation = sqs[:type].to_s =~ /^(delete|receive)/ ? 'receive' : 'publish'
+            return queue.empty? ? "SQS #{operation}" : "#{queue} #{operation}"
+          end
+
+          if (sns = data[:sns])
+            topic = sns[:topic].to_s.strip
+            topic = sns[:target].to_s.strip if topic.empty?
+            return topic.empty? ? 'SNS publish' : "#{topic} publish"
+          end
+
+          if (ddb = data[:dynamodb])
+            op = ddb[:op].to_s.strip
+            return op.empty? ? 'DynamoDB' : "DynamoDB.#{op}"
+          end
+
+          if (s3 = data[:s3])
+            op = s3[:op].to_s.strip
+            return op.empty? ? 'S3' : "S3.#{op}"
+          end
+
+          lambda_data = data.dig(:aws, :lambda, :invoke)
+          if lambda_data
+            fn = lambda_data[:function].to_s.strip
+            return fn.empty? ? 'Lambda.invoke' : "Lambda.#{fn}"
+          end
+
+          super
+        end
+
         def convert_attributes
           attributes = {}
 

--- a/lib/instana/exporter/otlp/aws_converter.rb
+++ b/lib/instana/exporter/otlp/aws_converter.rb
@@ -25,97 +25,122 @@ module Instana
         # @return [String] The span name
         def span_name
           data = span[:data] || {}
-
-          if (sqs = data[:sqs])
-            queue = sqs[:queue].to_s.strip
-            operation = sqs[:type].to_s =~ /^(delete|receive)/ ? 'receive' : 'publish'
-            return queue.empty? ? "SQS #{operation}" : "#{queue} #{operation}"
-          end
-
-          if (sns = data[:sns])
-            topic = sns[:topic].to_s.strip
-            topic = sns[:target].to_s.strip if topic.empty?
-            return topic.empty? ? 'SNS publish' : "#{topic} publish"
-          end
-
-          if (ddb = data[:dynamodb])
-            op = ddb[:op].to_s.strip
-            return op.empty? ? 'DynamoDB' : "DynamoDB.#{op}"
-          end
-
-          if (s3 = data[:s3])
-            op = s3[:op].to_s.strip
-            return op.empty? ? 'S3' : "S3.#{op}"
-          end
-
-          lambda_data = data.dig(:aws, :lambda, :invoke)
-          if lambda_data
-            fn = lambda_data[:function].to_s.strip
-            return fn.empty? ? 'Lambda.invoke' : "Lambda.#{fn}"
-          end
-
-          super
+          sqs_span_name(data[:sqs]) ||
+            sns_span_name(data[:sns]) ||
+            dynamodb_span_name(data[:dynamodb]) ||
+            s3_span_name(data[:s3]) ||
+            lambda_span_name(data.dig(:aws, :lambda, :invoke)) ||
+            super
         end
 
         def convert_attributes
           attributes = {}
+          data = span[:data]
+          return attributes unless data
 
-          # AWS SQS
-          sqs_data = span[:data]&.[](:sqs)
-          if sqs_data
-            add_attribute(attributes, OpenTelemetry::SemConv::Incubating::MESSAGING::MESSAGING_SYSTEM, 'aws_sqs')
-            add_attribute(attributes, OpenTelemetry::SemConv::Incubating::MESSAGING::MESSAGING_DESTINATION_NAME, sqs_data[:queue])
-            add_attribute(attributes, 'messaging.aws.sqs.message_group_id', sqs_data[:group])
-            add_attribute(attributes, OpenTelemetry::SemConv::Incubating::MESSAGING::MESSAGING_BATCH_MESSAGE_COUNT, sqs_data[:size])
-
-            operation = case sqs_data[:type]
-                        when /^send/, /^single\.sync/ then 'send'
-                        when /^delete/ then 'process'
-                        when /^create/, /^get/ then 'create'
-                        else 'send'
-                        end
-            add_attribute(attributes, OpenTelemetry::SemConv::Incubating::MESSAGING::MESSAGING_OPERATION_TYPE, operation)
-          end
-
-          # AWS SNS
-          sns_data = span[:data]&.[](:sns)
-          if sns_data
-            add_attribute(attributes, OpenTelemetry::SemConv::Incubating::MESSAGING::MESSAGING_SYSTEM, 'aws_sns')
-            add_attribute(attributes, OpenTelemetry::SemConv::Incubating::MESSAGING::MESSAGING_DESTINATION_NAME, sns_data[:topic])
-            add_attribute(attributes, 'messaging.aws.sns.target_arn', sns_data[:target])
-            add_attribute(attributes, 'messaging.aws.sns.phone_number', sns_data[:phone])
-            add_attribute(attributes, 'messaging.aws.sns.subject', sns_data[:subject])
-            add_attribute(attributes, OpenTelemetry::SemConv::Incubating::MESSAGING::MESSAGING_OPERATION_TYPE, 'send')
-          end
-
-          # AWS DynamoDB
-          dynamodb_data = span[:data]&.[](:dynamodb)
-          if dynamodb_data
-            add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_SYSTEM_NAME, 'dynamodb')
-            add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_OPERATION_NAME, dynamodb_data[:op])
-            add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_NAMESPACE, dynamodb_data[:table])
-            add_attribute(attributes, 'aws.dynamodb.table_name', dynamodb_data[:table])
-          end
-
-          # AWS S3
-          s3_data = span[:data]&.[](:s3)
-          if s3_data
-            add_attribute(attributes, 'aws.service', 's3')
-            add_attribute(attributes, 'aws.s3.bucket', s3_data[:bucket])
-            add_attribute(attributes, 'aws.s3.key', s3_data[:key])
-            add_attribute(attributes, 'aws.s3.operation', s3_data[:op])
-          end
-
-          # AWS Lambda
-          lambda_data = span[:data]&.[](:aws)&.[](:lambda)&.[](:invoke)
-          if lambda_data
-            add_attribute(attributes, 'aws.service', 'lambda')
-            add_attribute(attributes, 'aws.lambda.function_name', lambda_data[:function])
-            add_attribute(attributes, 'aws.lambda.invocation_type', lambda_data[:type])
-            add_attribute(attributes, 'faas.invoked_name', lambda_data[:function])
-          end
+          convert_sqs_attributes(attributes, data[:sqs])
+          convert_sns_attributes(attributes, data[:sns])
+          convert_dynamodb_attributes(attributes, data[:dynamodb])
+          convert_s3_attributes(attributes, data[:s3])
+          convert_lambda_attributes(attributes, data.dig(:aws, :lambda, :invoke))
 
           attributes
+        end
+
+        private
+
+        def sqs_span_name(sqs)
+          return unless sqs
+
+          queue = sqs[:queue].to_s.strip
+          operation = sqs[:type].to_s =~ /^(delete|receive)/ ? 'receive' : 'publish'
+          queue.empty? ? "SQS #{operation}" : "#{queue} #{operation}"
+        end
+
+        def sns_span_name(sns)
+          return unless sns
+
+          topic = sns[:topic].to_s.strip
+          topic = sns[:target].to_s.strip if topic.empty?
+          topic.empty? ? 'SNS publish' : "#{topic} publish"
+        end
+
+        def dynamodb_span_name(ddb)
+          return unless ddb
+
+          op = ddb[:op].to_s.strip
+          op.empty? ? 'DynamoDB' : "DynamoDB.#{op}"
+        end
+
+        def s3_span_name(s3_data)
+          return unless s3_data
+
+          op = s3_data[:op].to_s.strip
+          op.empty? ? 'S3' : "S3.#{op}"
+        end
+
+        def lambda_span_name(lambda_data)
+          return unless lambda_data
+
+          fn = lambda_data[:function].to_s.strip
+          fn.empty? ? 'Lambda.invoke' : "Lambda.#{fn}"
+        end
+
+        def convert_sqs_attributes(attributes, sqs_data)
+          return unless sqs_data
+
+          add_attribute(attributes, OpenTelemetry::SemConv::Incubating::MESSAGING::MESSAGING_SYSTEM, 'aws_sqs')
+          add_attribute(attributes, OpenTelemetry::SemConv::Incubating::MESSAGING::MESSAGING_DESTINATION_NAME, sqs_data[:queue])
+          add_attribute(attributes, 'messaging.aws.sqs.message_group_id', sqs_data[:group])
+          add_attribute(attributes, OpenTelemetry::SemConv::Incubating::MESSAGING::MESSAGING_BATCH_MESSAGE_COUNT, sqs_data[:size])
+          add_attribute(attributes, OpenTelemetry::SemConv::Incubating::MESSAGING::MESSAGING_OPERATION_TYPE, sqs_operation_type(sqs_data[:type]))
+        end
+
+        def sqs_operation_type(type)
+          case type.to_s
+          when /^send/, /^single\.sync/ then 'send'
+          when /^delete/ then 'process'
+          when /^create/, /^get/ then 'create'
+          else 'send'
+          end
+        end
+
+        def convert_sns_attributes(attributes, sns_data)
+          return unless sns_data
+
+          add_attribute(attributes, OpenTelemetry::SemConv::Incubating::MESSAGING::MESSAGING_SYSTEM, 'aws_sns')
+          add_attribute(attributes, OpenTelemetry::SemConv::Incubating::MESSAGING::MESSAGING_DESTINATION_NAME, sns_data[:topic])
+          add_attribute(attributes, 'messaging.aws.sns.target_arn', sns_data[:target])
+          add_attribute(attributes, 'messaging.aws.sns.phone_number', sns_data[:phone])
+          add_attribute(attributes, 'messaging.aws.sns.subject', sns_data[:subject])
+          add_attribute(attributes, OpenTelemetry::SemConv::Incubating::MESSAGING::MESSAGING_OPERATION_TYPE, 'send')
+        end
+
+        def convert_dynamodb_attributes(attributes, dynamodb_data)
+          return unless dynamodb_data
+
+          add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_SYSTEM_NAME, 'dynamodb')
+          add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_OPERATION_NAME, dynamodb_data[:op])
+          add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_NAMESPACE, dynamodb_data[:table])
+          add_attribute(attributes, 'aws.dynamodb.table_name', dynamodb_data[:table])
+        end
+
+        def convert_s3_attributes(attributes, s3_data)
+          return unless s3_data
+
+          add_attribute(attributes, 'aws.service', 's3')
+          add_attribute(attributes, 'aws.s3.bucket', s3_data[:bucket])
+          add_attribute(attributes, 'aws.s3.key', s3_data[:key])
+          add_attribute(attributes, 'aws.s3.operation', s3_data[:op])
+        end
+
+        def convert_lambda_attributes(attributes, lambda_data)
+          return unless lambda_data
+
+          add_attribute(attributes, 'aws.service', 'lambda')
+          add_attribute(attributes, 'aws.lambda.function_name', lambda_data[:function])
+          add_attribute(attributes, 'aws.lambda.invocation_type', lambda_data[:type])
+          add_attribute(attributes, 'faas.invoked_name', lambda_data[:function])
         end
       end
     end

--- a/lib/instana/exporter/otlp/background_job_converter.rb
+++ b/lib/instana/exporter/otlp/background_job_converter.rb
@@ -10,6 +10,25 @@ module Instana
   module Exporter
     module Otlp
       class BackgroundJobConverter < BaseConverter
+        # Build OTel-compliant span name for background-job spans
+        #
+        # Formula per SPAN_NAME_PATTERNS.txt Section 3 (sidekiq / resque):
+        #   client/producer → "{queue} publish"
+        #   worker/consumer → "{queue} process"
+        #
+        # @return [String] The span name
+        def span_name
+          span_type = span[:n].to_s
+          data_key  = span_type.to_sym
+          job_data  = span[data_key] || span[:data]&.[](data_key) || {}
+
+          queue = job_data[:queue] || job_data['queue']
+          queue = queue.to_s.strip
+
+          operation = span_type.end_with?('-client') ? 'publish' : 'process'
+          queue.empty? ? operation : "#{queue} #{operation}"
+        end
+
         def convert_attributes
           attributes = {}
 

--- a/lib/instana/exporter/otlp/base_converter.rb
+++ b/lib/instana/exporter/otlp/base_converter.rb
@@ -4,6 +4,7 @@
 
 require_relative 'resource'
 require 'opentelemetry/trace'
+require 'forwardable'
 
 module Instana
   module Exporter
@@ -30,6 +31,14 @@ module Instana
 
         # Represents the status of a span (OK, ERROR, or UNSET)
         Status = Struct.new(:code, :description)
+
+        # Represents a span event (mirrors OpenTelemetry::SDK::Trace::Event)
+        #
+        # Fields:
+        #   name       [String]  - event name
+        #   attributes [Hash]    - key/value attributes attached to the event
+        #   timestamp  [Integer] - Unix nanoseconds
+        Event = Struct.new(:name, :attributes, :timestamp)
 
         # Adapter to make resource objects compatible with OTLP exporter expectations
         ResourceAdapter = Struct.new(:attributes) do
@@ -68,12 +77,12 @@ module Instana
             attributes.size
           end
 
-          # @return [Array] Empty array (events not currently supported)
+          # @return [Array] Empty array — error-free spans carry no events
           def events
             EMPTY_ARRAY
           end
 
-          # @return [Integer] Zero (events not currently supported)
+          # @return [Integer] Zero — no events on error-free spans
           def total_recorded_events
             0
           end
@@ -101,6 +110,29 @@ module Instana
           EMPTY_ARRAY = [].freeze # rubocop:disable Lint/ConstantDefinitionInBlock
         end
 
+        # SpanData extended with an optional list of span events
+        #
+        # We wrap the base struct to carry events without changing the positional
+        # keyword_init constructor used by all converters.
+        SpanDataWithEvents = Struct.new(:span_data, :span_events) do
+          extend Forwardable
+          def_delegators :span_data,
+                         :name, :trace_id, :span_id, :parent_span_id,
+                         :resource, :instrumentation_scope, :kind,
+                         :start_timestamp, :end_timestamp, :attributes, :status,
+                         :tracestate, :total_recorded_attributes,
+                         :links, :total_recorded_links,
+                         :parent_span_is_remote, :trace_flags
+
+          def events
+            span_events
+          end
+
+          def total_recorded_events
+            span_events.size
+          end
+        end
+
         # Milliseconds to nanoseconds conversion factor
         MS_TO_NS = 1_000_000
         private_constant :MS_TO_NS
@@ -114,9 +146,14 @@ module Instana
 
         # Convert the Instana span to OTLP-compatible span data
         #
-        # @return [SpanData] Converted span data object ready for export
+        # @return [SpanData, SpanDataWithEvents] Converted span data object ready for export
         def convert
-          SpanData.new(
+          # Resolve error info once — reused by both status and events
+          error_count = span[:ec].to_i
+          error_msg   = error_count.positive? ? extract_error_message : nil
+          stacktrace  = error_count.positive? ? convert_stack_trace   : nil
+
+          span_data = SpanData.new(
             name: span_name,
             trace_id: format_trace_id(span[:t]),
             span_id: format_span_id(span[:s]),
@@ -127,8 +164,13 @@ module Instana
             start_timestamp: convert_to_unix_nano(span[:ts]),
             end_timestamp: calculate_end_timestamp,
             attributes: convert_attributes,
-            status: convert_status
+            status: build_status(error_count, error_msg)
           )
+
+          events = build_error_events(error_count, error_msg, stacktrace)
+          return SpanDataWithEvents.new(span_data, events) unless events.empty?
+
+          span_data
         end
 
         protected
@@ -194,22 +236,54 @@ module Instana
           end
         end
 
-        # Convert span status to OpenTelemetry status object
+        # Build span status from pre-resolved error info
         #
-        # @return [Status] Status object with code and optional description
-        def convert_status
-          if span[:error]
-            error_message = extract_error_message
-            Status.new(OpenTelemetry::Trace::Status::ERROR, error_message.to_s)
+        # @param error_count [Integer] Span error count (span[:ec].to_i)
+        # @param error_msg   [String, nil] Pre-extracted error message
+        # @return [Status]
+        def build_status(error_count, error_msg)
+          if error_count.positive?
+            Status.new(OpenTelemetry::Trace::Status::ERROR, error_msg.to_s)
           else
             Status.new(OpenTelemetry::Trace::Status::UNSET, '')
           end
         end
 
-        # Extract error message from span
-        # @return [String, nil] Error message
+        # Extract error message from span data
+        #
+        # Searches `span[:data][<type>][:error]` for any span type that
+        # carries an error field (e.g. http.error, activerecord.error).
+        # Returns the first non-nil value found, truncated to 1024 chars
+        # per the OTel status.message recommendation.
+        #
+        # @return [String, nil] Error message or nil when not present
         def extract_error_message
-          # TODO: Implement error message extraction
+          data = span[:data]
+          return nil unless data.is_a?(Hash)
+
+          data.each_value do |type_data|
+            next unless type_data.is_a?(Hash)
+
+            msg = type_data[:error]
+            return msg.to_s[0, 1024] if msg
+          end
+
+          nil
+        end
+
+        # Convert Instana stack trace to OTel exception.stacktrace string
+        #
+        # Instana stores stack frames as an Array of Hashes with keys:
+        #   c: file path, n: line number, m: method name
+        #
+        # OTel requires a newline-separated string of stack frames.
+        #
+        # @return [String, nil] Formatted stacktrace or nil if not present
+        def convert_stack_trace
+          stack = span[:stack]
+          return nil unless stack.is_a?(Array) && !stack.empty?
+
+          stack.map { |frame| "#{frame[:c]}:#{frame[:n]} in #{frame[:m]}" }.join("\n")
         end
 
         # Convert span attributes to OTLP-compatible attributes
@@ -220,6 +294,31 @@ module Instana
         # @return [Hash] Hash of attribute key-value pairs
         def convert_attributes
           {}
+        end
+
+        # Build OTel span events from pre-resolved error info
+        #
+        #   - error_count > 0 AND stacktrace present → "exception" event
+        #   - error_count > 0, no stack              → "error" event
+        #   - error_count == 0                       → []
+        #
+        # @param error_count [Integer]
+        # @param error_msg   [String, nil]
+        # @param stacktrace  [String, nil]
+        # @return [Array<Event>]
+        def build_error_events(error_count, error_msg, stacktrace)
+          return [] unless error_count.positive?
+
+          timestamp = calculate_end_timestamp
+
+          if stacktrace
+            attrs = { 'exception.type' => span_name }
+            attrs['exception.message']    = error_msg if error_msg
+            attrs['exception.stacktrace'] = stacktrace
+            [Event.new('exception', attrs, timestamp)]
+          else
+            [Event.new('error', { 'error.type' => span_name }, timestamp)]
+          end
         end
 
         # Add an attribute to the attributes hash if value is not nil
@@ -257,9 +356,18 @@ module Instana
 
         # Get the span name as a string
         #
+        # For custom (SDK) spans the user-supplied name is stored in
+        # span[:data][:sdk][:name], not in span[:n] (which is always :sdk).
+        # We read that path directly to avoid crashing when sdk data has been
+        # overwritten by tests or other code. Non-custom spans use span[:n].
+        #
         # @return [String] The span name
         def span_name
-          span[:n].to_s
+          if span.respond_to?(:custom?) ? span.custom? : span[:n]&.to_sym == :sdk
+            span[:data]&.dig(:sdk, :name).to_s
+          else
+            span[:n].to_s
+          end
         end
 
         # Format parent span ID, returning INVALID_SPAN_ID if no parent

--- a/lib/instana/exporter/otlp/custom_converter.rb
+++ b/lib/instana/exporter/otlp/custom_converter.rb
@@ -7,6 +7,18 @@ module Instana
     module Otlp
       # Converter for Instana SDK custom spans to OTLP format
       class CustomConverter < BaseConverter
+        # Build OTel-compliant span name for custom (SDK) spans
+        #
+        # Formula per SPAN_NAME_PATTERNS.txt Section 7:
+        #   Use the user-supplied sdk[:name] when available, otherwise fall back
+        #   to the internal span type key (span[:n]).
+        #
+        # @return [String] The span name
+        def span_name
+          sdk_name = span[:data]&.[](:sdk)&.[](:name).to_s.strip
+          sdk_name.empty? ? super : sdk_name
+        end
+
         def convert_attributes
           attributes = {}
           sdk_data = span[:data]&.[](:sdk) || {}

--- a/lib/instana/exporter/otlp/database_converter.rb
+++ b/lib/instana/exporter/otlp/database_converter.rb
@@ -70,6 +70,50 @@ module Instana
           attributes
         end
 
+        # Build OTel-compliant span name for database spans
+        #
+        # Formulas per SPAN_NAME_PATTERNS.txt Section 2:
+        #   activerecord / sequel  → "{adapter} {db}"       e.g. "mysql2 myapp"
+        #   redis                  → "redis {command}"       e.g. "redis GET"
+        #   memcache               → "memcached {command}"   e.g. "memcached get"
+        #   mongo                  → "{namespace}.{command}" e.g. "users.find"
+        #
+        # @return [String] The span name
+        def span_name
+          data = span[:data] || {}
+
+          if (ar = data[:activerecord])
+            parts = [ar[:adapter], ar[:db]].compact.reject(&:empty?)
+            return parts.empty? ? 'activerecord' : parts.join(' ')
+          end
+
+          if (seq = data[:sequel])
+            parts = [seq[:adapter], seq[:db]].compact.reject(&:empty?)
+            return parts.empty? ? 'sequel' : parts.join(' ')
+          end
+
+          if (redis = data[:redis])
+            cmd = redis[:command].to_s.strip
+            return cmd.empty? ? 'redis' : "redis #{cmd}"
+          end
+
+          if (mc = data[:memcache])
+            cmd = mc[:command].to_s.strip
+            return cmd.empty? ? 'memcached' : "memcached #{cmd}"
+          end
+
+          if (mongo = data[:mongo])
+            ns  = mongo[:namespace].to_s.strip
+            cmd = mongo[:command].to_s.strip
+            parts = [ns, cmd].reject(&:empty?)
+            return parts.join('.') unless parts.empty?
+
+            return 'mongodb'
+          end
+
+          super
+        end
+
         private
 
         def extract_host(connection)

--- a/lib/instana/exporter/otlp/database_converter.rb
+++ b/lib/instana/exporter/otlp/database_converter.rb
@@ -13,59 +13,13 @@ module Instana
       class DatabaseConverter < BaseConverter
         def convert_attributes
           attributes = {}
-          Instana.logger.info("inside database converter")
-          # ActiveRecord
-          ar_data = span[:data]&.[](:activerecord)
-          if ar_data
-            add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_SYSTEM_NAME, ar_data[:adapter])
-            add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_NAMESPACE, ar_data[:db])
-            add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_QUERY_TEXT, ar_data[:sql])
-            add_attribute(attributes, OpenTelemetry::SemConv::Incubating::DB::DB_USER, ar_data[:username])
-            add_attribute(attributes, OpenTelemetry::SemConv::SERVER::SERVER_ADDRESS, ar_data[:host])
-          end
+          data = span[:data] || {}
 
-          # Sequel
-          seq_data = span[:data]&.[](:sequel)
-          if seq_data
-            add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_SYSTEM_NAME, seq_data[:adapter])
-            add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_NAMESPACE, seq_data[:db])
-            add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_QUERY_TEXT, seq_data[:sql])
-            add_attribute(attributes, OpenTelemetry::SemConv::Incubating::DB::DB_USER, seq_data[:username])
-            add_attribute(attributes, OpenTelemetry::SemConv::SERVER::SERVER_ADDRESS, seq_data[:host])
-          end
-
-          # Redis
-          redis_data = span[:data]&.[](:redis)
-          if redis_data
-            add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_SYSTEM_NAME, 'redis')
-            add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_QUERY_TEXT, redis_data[:command])
-            add_attribute(attributes, 'db.redis.database_index', redis_data[:db])
-            add_attribute(attributes, OpenTelemetry::SemConv::SERVER::SERVER_ADDRESS, extract_host(redis_data[:connection]))
-            add_attribute(attributes, OpenTelemetry::SemConv::SERVER::SERVER_PORT, extract_port(redis_data[:connection]))
-          end
-
-          # Memcache (Dalli)
-          mc_data = span[:data]&.[](:memcache)
-          if mc_data
-            add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_SYSTEM_NAME, 'memcached')
-            add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_OPERATION_NAME, mc_data[:command])
-            add_attribute(attributes, 'db.memcached.key', mc_data[:key])
-            add_attribute(attributes, 'db.memcached.keys', mc_data[:keys])
-            add_attribute(attributes, 'db.memcached.namespace', mc_data[:namespace])
-            add_attribute(attributes, OpenTelemetry::SemConv::SERVER::SERVER_ADDRESS, extract_host(mc_data[:server]))
-            add_attribute(attributes, OpenTelemetry::SemConv::SERVER::SERVER_PORT, extract_port(mc_data[:server]))
-          end
-
-          # MongoDB
-          mongo_data = span[:data]&.[](:mongo)
-          if mongo_data
-            add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_SYSTEM_NAME, 'mongodb')
-            add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_NAMESPACE, mongo_data[:namespace])
-            add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_OPERATION_NAME, mongo_data[:command])
-            add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_QUERY_TEXT, mongo_data[:json])
-            add_attribute(attributes, OpenTelemetry::SemConv::SERVER::SERVER_ADDRESS, mongo_data.dig(:peer, :hostname))
-            add_attribute(attributes, OpenTelemetry::SemConv::SERVER::SERVER_PORT, mongo_data.dig(:peer, :port))
-          end
+          convert_activerecord_attributes(attributes, data[:activerecord])
+          convert_sequel_attributes(attributes, data[:sequel])
+          convert_redis_attributes(attributes, data[:redis])
+          convert_memcache_attributes(attributes, data[:memcache])
+          convert_mongo_attributes(attributes, data[:mongo])
 
           attributes
         end
@@ -81,40 +35,105 @@ module Instana
         # @return [String] The span name
         def span_name
           data = span[:data] || {}
-
-          if (ar = data[:activerecord])
-            parts = [ar[:adapter], ar[:db]].compact.reject(&:empty?)
-            return parts.empty? ? 'activerecord' : parts.join(' ')
-          end
-
-          if (seq = data[:sequel])
-            parts = [seq[:adapter], seq[:db]].compact.reject(&:empty?)
-            return parts.empty? ? 'sequel' : parts.join(' ')
-          end
-
-          if (redis = data[:redis])
-            cmd = redis[:command].to_s.strip
-            return cmd.empty? ? 'redis' : "redis #{cmd}"
-          end
-
-          if (mc = data[:memcache])
-            cmd = mc[:command].to_s.strip
-            return cmd.empty? ? 'memcached' : "memcached #{cmd}"
-          end
-
-          if (mongo = data[:mongo])
-            ns  = mongo[:namespace].to_s.strip
-            cmd = mongo[:command].to_s.strip
-            parts = [ns, cmd].reject(&:empty?)
-            return parts.join('.') unless parts.empty?
-
-            return 'mongodb'
-          end
-
-          super
+          activerecord_span_name(data[:activerecord]) ||
+            sequel_span_name(data[:sequel]) ||
+            redis_span_name(data[:redis]) ||
+            memcache_span_name(data[:memcache]) ||
+            mongo_span_name(data[:mongo]) ||
+            super
         end
 
         private
+
+        def activerecord_span_name(ar_data)
+          return unless ar_data
+
+          parts = [ar_data[:adapter], ar_data[:db]].compact.reject(&:empty?)
+          parts.empty? ? 'activerecord' : parts.join(' ')
+        end
+
+        def sequel_span_name(seq)
+          return unless seq
+
+          parts = [seq[:adapter], seq[:db]].compact.reject(&:empty?)
+          parts.empty? ? 'sequel' : parts.join(' ')
+        end
+
+        def redis_span_name(redis)
+          return unless redis
+
+          cmd = redis[:command].to_s.strip
+          cmd.empty? ? 'redis' : "redis #{cmd}"
+        end
+
+        def memcache_span_name(mc_data)
+          return unless mc_data
+
+          cmd = mc_data[:command].to_s.strip
+          cmd.empty? ? 'memcached' : "memcached #{cmd}"
+        end
+
+        def mongo_span_name(mongo)
+          return unless mongo
+
+          ns  = mongo[:namespace].to_s.strip
+          cmd = mongo[:command].to_s.strip
+          parts = [ns, cmd].reject(&:empty?)
+          parts.empty? ? 'mongodb' : parts.join('.')
+        end
+
+        def convert_activerecord_attributes(attributes, ar_data)
+          return unless ar_data
+
+          add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_SYSTEM_NAME, ar_data[:adapter])
+          add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_NAMESPACE, ar_data[:db])
+          add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_QUERY_TEXT, ar_data[:sql])
+          add_attribute(attributes, OpenTelemetry::SemConv::Incubating::DB::DB_USER, ar_data[:username])
+          add_attribute(attributes, OpenTelemetry::SemConv::SERVER::SERVER_ADDRESS, ar_data[:host])
+        end
+
+        def convert_sequel_attributes(attributes, seq_data)
+          return unless seq_data
+
+          add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_SYSTEM_NAME, seq_data[:adapter])
+          add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_NAMESPACE, seq_data[:db])
+          add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_QUERY_TEXT, seq_data[:sql])
+          add_attribute(attributes, OpenTelemetry::SemConv::Incubating::DB::DB_USER, seq_data[:username])
+          add_attribute(attributes, OpenTelemetry::SemConv::SERVER::SERVER_ADDRESS, seq_data[:host])
+        end
+
+        def convert_redis_attributes(attributes, redis_data)
+          return unless redis_data
+
+          add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_SYSTEM_NAME, 'redis')
+          add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_QUERY_TEXT, redis_data[:command])
+          add_attribute(attributes, 'db.redis.database_index', redis_data[:db])
+          add_attribute(attributes, OpenTelemetry::SemConv::SERVER::SERVER_ADDRESS, extract_host(redis_data[:connection]))
+          add_attribute(attributes, OpenTelemetry::SemConv::SERVER::SERVER_PORT, extract_port(redis_data[:connection]))
+        end
+
+        def convert_memcache_attributes(attributes, mc_data)
+          return unless mc_data
+
+          add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_SYSTEM_NAME, 'memcached')
+          add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_OPERATION_NAME, mc_data[:command])
+          add_attribute(attributes, 'db.memcached.key', mc_data[:key])
+          add_attribute(attributes, 'db.memcached.keys', mc_data[:keys])
+          add_attribute(attributes, 'db.memcached.namespace', mc_data[:namespace])
+          add_attribute(attributes, OpenTelemetry::SemConv::SERVER::SERVER_ADDRESS, extract_host(mc_data[:server]))
+          add_attribute(attributes, OpenTelemetry::SemConv::SERVER::SERVER_PORT, extract_port(mc_data[:server]))
+        end
+
+        def convert_mongo_attributes(attributes, mongo_data)
+          return unless mongo_data
+
+          add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_SYSTEM_NAME, 'mongodb')
+          add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_NAMESPACE, mongo_data[:namespace])
+          add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_OPERATION_NAME, mongo_data[:command])
+          add_attribute(attributes, OpenTelemetry::SemConv::DB::DB_QUERY_TEXT, mongo_data[:json])
+          add_attribute(attributes, OpenTelemetry::SemConv::SERVER::SERVER_ADDRESS, mongo_data.dig(:peer, :hostname))
+          add_attribute(attributes, OpenTelemetry::SemConv::SERVER::SERVER_PORT, mongo_data.dig(:peer, :port))
+        end
 
         def extract_host(connection)
           return nil unless connection

--- a/lib/instana/exporter/otlp/graphql_converter.rb
+++ b/lib/instana/exporter/otlp/graphql_converter.rb
@@ -10,6 +10,27 @@ module Instana
     module Otlp
       # Converter for GraphQL spans to OTLP format
       class GraphqlConverter < BaseConverter
+        # Build OTel-compliant span name for GraphQL spans
+        #
+        # Formula per SPAN_NAME_PATTERNS.txt Section 7 (observability):
+        #   "{operationType} {operationName}"  e.g. "query MyQuery"
+        #   Falls back to just "{operationType}" when no name, or "graphql" when both absent.
+        #
+        # @return [String] The span name
+        def span_name
+          gql = span[:data]&.[](:graphql) || {}
+          type = gql[:operationType].to_s.strip
+          name = gql[:operationName].to_s.strip
+
+          if type.empty?
+            'graphql'
+          elsif name.empty?
+            type
+          else
+            "#{type} #{name}"
+          end
+        end
+
         def convert_attributes
           attributes = {}
 

--- a/lib/instana/exporter/otlp/grpc_converter.rb
+++ b/lib/instana/exporter/otlp/grpc_converter.rb
@@ -10,6 +10,17 @@ module Instana
     module Otlp
       # Converter for gRPC spans to OTLP format
       class GrpcConverter < BaseConverter
+        # Build OTel-compliant span name for gRPC spans
+        #
+        # Formula per SPAN_NAME_PATTERNS.txt Section 4:
+        #   "{package.Service/Method}"  — leading "/" stripped per OTel spec
+        #
+        # @return [String] The span name
+        def span_name
+          call = span[:data]&.[](:rpc)&.[](:call).to_s.delete_prefix('/')
+          call.empty? ? super : call
+        end
+
         def convert_attributes
           attributes = {}
 

--- a/lib/instana/exporter/otlp/http_converter.rb
+++ b/lib/instana/exporter/otlp/http_converter.rb
@@ -31,6 +31,21 @@ module Instana
           attributes
         end
 
+        # Build OTel-compliant span name for HTTP spans
+        #
+        # Convention (stable): "{METHOD}" or "{METHOD} {url.template/path}"
+        # Falls back to "HTTP" when no method is present.
+        #
+        # @return [String] The span name
+        def span_name
+          http_data = span[:data]&.[](:http) || {}
+          method = http_data[:method].to_s.upcase
+          method = 'HTTP' if method.empty?
+
+          path = http_data[:path].to_s.strip
+          path.empty? ? method : "#{method} #{path}"
+        end
+
         # Extract scheme from URL
         # @param url [String] The URL
         # @return [String, nil] The scheme (http or https)

--- a/lib/instana/exporter/otlp/messaging_converter.rb
+++ b/lib/instana/exporter/otlp/messaging_converter.rb
@@ -11,6 +11,27 @@ module Instana
     module Otlp
       # Converter for messaging spans to OTLP format
       class MessagingConverter < BaseConverter
+        # Build OTel-compliant span name for messaging (RabbitMQ) spans
+        #
+        # Formula per SPAN_NAME_PATTERNS.txt Section 3 (bunny/AMQP):
+        #   publish → "{exchange} publish"   (or "{queue} publish" when no exchange)
+        #   receive → "{queue} receive"
+        #
+        # @return [String] The span name
+        def span_name
+          rabbitmq_data = span[:data]&.[](:rabbitmq) || {}
+          sort = rabbitmq_data[:sort].to_s
+
+          if sort == 'publish'
+            dest = rabbitmq_data[:exchange].to_s.strip
+            dest = rabbitmq_data[:queue].to_s.strip if dest.empty?
+            dest.empty? ? 'publish' : "#{dest} publish"
+          else
+            queue = rabbitmq_data[:queue].to_s.strip
+            queue.empty? ? 'receive' : "#{queue} receive"
+          end
+        end
+
         def convert_attributes
           attributes = {}
 

--- a/lib/instana/exporter/otlp/rails_converter.rb
+++ b/lib/instana/exporter/otlp/rails_converter.rb
@@ -10,6 +10,43 @@ module Instana
     module Otlp
       # Converter for Rails-related spans (ActionController, ActionView, ActionMailer) to OTLP format
       class RailsConverter < BaseConverter
+        # Build OTel-compliant span name for Rails spans
+        #
+        # Formulas per SPAN_NAME_PATTERNS.txt Sections 5 & 7:
+        #   actioncontroller  → "{Controller}#{action}"    e.g. "UsersController#index"
+        #   actionview        → "{view_name}"              e.g. "users/index"
+        #   render            → "{type} {name}"            e.g. "template users/index"
+        #   mail.actionmailer → "{Class}#{method}"         e.g. "UserMailer#welcome_email"
+        #
+        # @return [String] The span name
+        def span_name # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+          case span[:n].to_s
+          when 'actioncontroller'
+            d = span[:data]&.[](:actioncontroller) || span[:actioncontroller] || {}
+            ctrl   = d[:controller].to_s.strip
+            action = d[:action].to_s.strip
+            parts  = [ctrl, action].reject(&:empty?)
+            parts.empty? ? 'actioncontroller' : parts.join('#')
+          when 'actionview'
+            d = span[:data]&.[](:actionview) || span[:actionview] || {}
+            d[:name].to_s.strip.then { |n| n.empty? ? 'actionview' : n }
+          when 'render'
+            d = span[:data]&.[](:render) || span[:render] || {}
+            type = d[:type].to_s.strip
+            name = d[:name].to_s.strip
+            parts = [type, name].reject(&:empty?)
+            parts.empty? ? 'render' : parts.join(' ')
+          when 'mail.actionmailer'
+            d = span[:data]&.[](:actionmailer) || span[:actionmailer] || {}
+            klass  = d[:class].to_s.strip
+            method = d[:method].to_s.strip
+            parts  = [klass, method].reject(&:empty?)
+            parts.empty? ? 'mail.actionmailer' : parts.join('#')
+          else
+            super
+          end
+        end
+
         def convert_attributes
           attributes = {}
 

--- a/lib/instana/exporter/otlp/rails_converter.rb
+++ b/lib/instana/exporter/otlp/rails_converter.rb
@@ -10,6 +10,8 @@ module Instana
     module Otlp
       # Converter for Rails-related spans (ActionController, ActionView, ActionMailer) to OTLP format
       class RailsConverter < BaseConverter
+        ACTIONMAILER_SPAN = 'mail.actionmailer'
+
         # Build OTel-compliant span name for Rails spans
         #
         # Formulas per SPAN_NAME_PATTERNS.txt Sections 5 & 7:
@@ -19,29 +21,29 @@ module Instana
         #   mail.actionmailer → "{Class}#{method}"         e.g. "UserMailer#welcome_email"
         #
         # @return [String] The span name
-        def span_name # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        def span_name
           case span[:n].to_s
           when 'actioncontroller'
-            d = span[:data]&.[](:actioncontroller) || span[:actioncontroller] || {}
+            d = span_data_for(:actioncontroller)
             ctrl   = d[:controller].to_s.strip
             action = d[:action].to_s.strip
             parts  = [ctrl, action].reject(&:empty?)
             parts.empty? ? 'actioncontroller' : parts.join('#')
           when 'actionview'
-            d = span[:data]&.[](:actionview) || span[:actionview] || {}
+            d = span_data_for(:actionview)
             d[:name].to_s.strip.then { |n| n.empty? ? 'actionview' : n }
           when 'render'
-            d = span[:data]&.[](:render) || span[:render] || {}
+            d = span_data_for(:render)
             type = d[:type].to_s.strip
             name = d[:name].to_s.strip
             parts = [type, name].reject(&:empty?)
             parts.empty? ? 'render' : parts.join(' ')
-          when 'mail.actionmailer'
-            d = span[:data]&.[](:actionmailer) || span[:actionmailer] || {}
+          when ACTIONMAILER_SPAN
+            d = span_data_for(:actionmailer)
             klass  = d[:class].to_s.strip
             method = d[:method].to_s.strip
             parts  = [klass, method].reject(&:empty?)
-            parts.empty? ? 'mail.actionmailer' : parts.join('#')
+            parts.empty? ? ACTIONMAILER_SPAN : parts.join('#')
           else
             super
           end
@@ -57,7 +59,7 @@ module Instana
             convert_action_view_attributes(attributes)
           when 'render'
             convert_render_attributes(attributes)
-          when 'mail.actionmailer'
+          when ACTIONMAILER_SPAN
             convert_action_mailer_attributes(attributes)
           end
 
@@ -65,6 +67,12 @@ module Instana
         end
 
         private
+
+        # Return the data hash for a given span data key, falling back to
+        # top-level span key, then an empty hash.
+        def span_data_for(key)
+          span[:data]&.[](key) || span[key] || {}
+        end
 
         # Convert ActionController span attributes
         def convert_action_controller_attributes(attributes)

--- a/lib/instana/exporter/otlp/rpc_converter.rb
+++ b/lib/instana/exporter/otlp/rpc_converter.rb
@@ -12,6 +12,24 @@ module Instana
     module Otlp
       # Converter for RPC spans (gRPC, ActionCable) to OTLP format
       class RpcConverter < BaseConverter
+        # Build OTel-compliant span name for RPC spans
+        #
+        # Formulas per SPAN_NAME_PATTERNS.txt Section 4:
+        #   gRPC        → "{package.Service/Method}"  (leading "/" stripped per OTel spec)
+        #   ActionCable → "{ChannelClass#action}"      (call string used as-is)
+        #
+        # @return [String] The span name
+        def span_name
+          rpc_data = span[:data]&.[](:rpc) || {}
+
+          if rpc_data[:flavor] == :actioncable
+            rpc_data[:call].to_s
+          else
+            # Strip the mandatory leading slash per gRPC/OTel spec
+            rpc_data[:call].to_s.delete_prefix('/')
+          end.then { |n| n.empty? ? super : n }
+        end
+
         def convert_attributes
           attributes = {}
 

--- a/test/exporter/otlp/aws_converter_test.rb
+++ b/test/exporter/otlp/aws_converter_test.rb
@@ -345,6 +345,55 @@ class AwsConverterTest < Minitest::Test # rubocop:disable Metrics/ClassLength
     assert_kind_of Instana::Exporter::Otlp::BaseConverter, converter
   end
 
+  # --- span_name tests ---
+
+  def test_span_name_sqs_send
+    span = create_span('aws.sqs', { sqs: { queue: 'my-queue', type: 'send' } })
+    result = Instana::Exporter::Otlp::AwsConverter.new(span).convert
+    assert_equal 'my-queue publish', result[:name]
+  end
+
+  def test_span_name_sqs_delete_maps_to_receive
+    span = create_span('aws.sqs', { sqs: { queue: 'my-queue', type: 'delete' } })
+    result = Instana::Exporter::Otlp::AwsConverter.new(span).convert
+    assert_equal 'my-queue receive', result[:name]
+  end
+
+  def test_span_name_sns_publish
+    span = create_span('aws.sns', { sns: { topic: 'my-topic' } })
+    result = Instana::Exporter::Otlp::AwsConverter.new(span).convert
+    assert_equal 'my-topic publish', result[:name]
+  end
+
+  def test_span_name_dynamodb
+    span = create_span('aws.dynamodb', { dynamodb: { op: 'PutItem', table: 'users' } })
+    result = Instana::Exporter::Otlp::AwsConverter.new(span).convert
+    assert_equal 'DynamoDB.PutItem', result[:name]
+  end
+
+  def test_span_name_s3
+    span = create_span('aws.s3', { s3: { bucket: 'b', key: 'k', op: 'GetObject' } })
+    result = Instana::Exporter::Otlp::AwsConverter.new(span).convert
+    assert_equal 'S3.GetObject', result[:name]
+  end
+
+  def test_span_name_lambda
+    span = create_span('aws.lambda', { aws: { lambda: { invoke: { function: 'my-fn', type: 'RequestResponse' } } } })
+    result = Instana::Exporter::Otlp::AwsConverter.new(span).convert
+    assert_equal 'Lambda.my-fn', result[:name]
+  end
+
+  def test_span_name_falls_back_to_user_supplied_name_when_no_aws_data
+    # Instana::Span normalises unregistered names to :sdk but stores the
+    # user-supplied name in span[:data][:sdk][:name].
+    # We must not overwrite :data so we do NOT call create_span (which sets
+    # span[:data] = {}). Instead build the span manually.
+    span = Instana::Span.new(:'aws.unknown')
+    span.close
+    result = Instana::Exporter::Otlp::AwsConverter.new(span).convert
+    assert_equal 'aws.unknown', result[:name]
+  end
+
   def test_full_span_conversion_with_sqs
     span = create_span('aws.sqs', {
                          sqs: { queue: 'integration-queue', type: 'send', size: 10 }

--- a/test/exporter/otlp/background_job_converter_test.rb
+++ b/test/exporter/otlp/background_job_converter_test.rb
@@ -84,6 +84,38 @@ class BackgroundJobConverterTest < Minitest::Test
     assert_empty attrs
   end
 
+  # --- span_name tests ---
+
+  def test_span_name_sidekiq_client_publish
+    span = create_span('sidekiq-client', { 'sidekiq-client': { queue: 'default', job: 'MyWorker' } })
+    result = Instana::Exporter::Otlp::BackgroundJobConverter.new(span).convert
+    assert_equal 'default publish', result[:name]
+  end
+
+  def test_span_name_sidekiq_worker_process
+    span = create_span('sidekiq-worker', { 'sidekiq-worker': { queue: 'critical', job: 'MyWorker' } })
+    result = Instana::Exporter::Otlp::BackgroundJobConverter.new(span).convert
+    assert_equal 'critical process', result[:name]
+  end
+
+  def test_span_name_resque_client_publish
+    span = create_span('resque-client', { 'resque-client': { queue: 'low' } })
+    result = Instana::Exporter::Otlp::BackgroundJobConverter.new(span).convert
+    assert_equal 'low publish', result[:name]
+  end
+
+  def test_span_name_resque_worker_process
+    span = create_span('resque-worker', { 'resque-worker': { queue: 'high' } })
+    result = Instana::Exporter::Otlp::BackgroundJobConverter.new(span).convert
+    assert_equal 'high process', result[:name]
+  end
+
+  def test_span_name_falls_back_to_operation_when_no_queue
+    span = create_span('sidekiq-worker', { 'sidekiq-worker': {} })
+    result = Instana::Exporter::Otlp::BackgroundJobConverter.new(span).convert
+    assert_equal 'process', result[:name]
+  end
+
   private
 
   def create_span(name, data)

--- a/test/exporter/otlp/base_converter_test.rb
+++ b/test/exporter/otlp/base_converter_test.rb
@@ -81,23 +81,178 @@ class BaseConverterTest < Minitest::Test
   end
 
   def test_convert_status
-    # Test UNSET status (no error)
+    # Test UNSET status (no error — ec is 0 or absent)
     span = create_test_span(name: :rack)
     converter = TestConverter.new(span)
-    status = converter.send(:convert_status)
+    status = converter.send(:build_status, span[:ec].to_i, nil)
     assert_equal OpenTelemetry::Trace::Status::UNSET, status.code
     assert_equal '', status.description
 
-    # Test ERROR status
+    # Test ERROR status driven by span.ec > 0
     span = create_test_span(name: :rack)
     span.record_exception(StandardError.new('Test error'))
     converter = TestConverter.new(span)
-    status = converter.send(:convert_status)
+    status = converter.send(:build_status, span[:ec].to_i, converter.send(:extract_error_message))
     assert_equal OpenTelemetry::Trace::Status::ERROR, status.code
   end
 
+  def test_convert_status_uses_ec_not_error_flag
+    # span.ec > 0 should always yield ERROR, independent of :error flag
+    span = create_test_span(name: :rack)
+    span[:ec] = 2
+    converter = TestConverter.new(span)
+    status = converter.send(:build_status, span[:ec].to_i, nil)
+    assert_equal OpenTelemetry::Trace::Status::ERROR, status.code
+
+    # ec == 0 should yield UNSET even when :error is true
+    span2 = create_test_span(name: :rack)
+    span2[:error] = true
+    span2[:ec] = 0
+    converter2 = TestConverter.new(span2)
+    status2 = converter2.send(:build_status, span2[:ec].to_i, nil)
+    assert_equal OpenTelemetry::Trace::Status::UNSET, status2.code
+  end
+
+  def test_extract_error_message_returns_nil_when_no_data
+    span = create_test_span(name: :rack)
+    converter = TestConverter.new(span)
+    assert_nil converter.send(:extract_error_message)
+  end
+
+  def test_extract_error_message_finds_error_in_type_data
+    span = create_test_span(name: :rack, data: { http: { error: 'Connection refused' } })
+    converter = TestConverter.new(span)
+    assert_equal 'Connection refused', converter.send(:extract_error_message)
+  end
+
+  def test_extract_error_message_truncates_to_1024_chars
+    long_msg = 'x' * 2000
+    span = create_test_span(name: :rack, data: { http: { error: long_msg } })
+    converter = TestConverter.new(span)
+    result = converter.send(:extract_error_message)
+    assert_equal 1024, result.length
+  end
+
+  def test_convert_stack_trace_returns_nil_when_no_stack
+    span = create_test_span(name: :rack)
+    converter = TestConverter.new(span)
+    assert_nil converter.send(:convert_stack_trace)
+  end
+
+  def test_convert_stack_trace_formats_frames_as_string
+    span = create_test_span(name: :rack)
+    span[:stack] = [
+      { c: '/app/models/user.rb', n: '42', m: 'in `save`' },
+      { c: '/app/controllers/users_controller.rb', n: '10', m: 'in `create`' }
+    ]
+    converter = TestConverter.new(span)
+    result = converter.send(:convert_stack_trace)
+    assert_equal "/app/models/user.rb:42 in in `save`\n" \
+                 "/app/controllers/users_controller.rb:10 in in `create`",
+                 result
+  end
+
+  def test_convert_stack_trace_returns_nil_for_empty_stack
+    span = create_test_span(name: :rack)
+    span[:stack] = []
+    converter = TestConverter.new(span)
+    assert_nil converter.send(:convert_stack_trace)
+  end
+
+  # --- build_error_events / event-based error recording ---
+
+  def test_no_error_events_when_no_error
+    span = create_test_span(name: :rack)
+    converter = TestConverter.new(span)
+    assert_equal [], converter.send(:build_error_events, span[:ec].to_i, nil, nil)
+  end
+
+  def test_exception_event_emitted_when_ec_positive_and_stack_present
+    span = create_test_span(name: :rack, data: { http: { error: 'Timeout' } })
+    span[:stack] = [{ c: '/app/lib/client.rb', n: '7', m: 'in `call`' }]
+    span[:ec] = 1
+    converter = TestConverter.new(span)
+    events = converter.send(:build_error_events, span[:ec].to_i, converter.send(:extract_error_message), converter.send(:convert_stack_trace))
+
+    assert_equal 1, events.size
+    event = events.first
+    assert_equal 'exception', event.name
+    assert_equal 'rack', event.attributes['exception.type']
+    assert_equal 'Timeout', event.attributes['exception.message']
+    assert_equal '/app/lib/client.rb:7 in in `call`', event.attributes['exception.stacktrace']
+    assert_kind_of Integer, event.timestamp
+  end
+
+  def test_error_event_emitted_when_ec_positive_but_no_stack
+    span = create_test_span(name: :rack, data: { http: { error: 'Timeout' } })
+    span[:ec] = 1
+    converter = TestConverter.new(span)
+    events = converter.send(:build_error_events, span[:ec].to_i, converter.send(:extract_error_message), converter.send(:convert_stack_trace))
+
+    assert_equal 1, events.size
+    event = events.first
+    assert_equal 'error', event.name
+    assert_equal 'rack', event.attributes['error.type']
+  end
+
+  def test_convert_returns_span_data_with_events_on_error
+    span = create_test_span(name: :rack, data: { http: { error: 'Timeout' } })
+    span[:stack] = [{ c: '/app/lib/client.rb', n: '7', m: 'in `call`' }]
+    span[:ec] = 1
+    converter = TestConverter.new(span)
+    result = converter.convert
+
+    assert_instance_of Instana::Exporter::Otlp::BaseConverter::SpanDataWithEvents, result
+    assert_equal 1, result.total_recorded_events
+    assert_equal 'exception', result.events.first.name
+  end
+
+  def test_convert_returns_plain_span_data_when_no_error
+    span = create_test_span(name: :rack)
+    converter = TestConverter.new(span)
+    result = converter.convert
+
+    assert_instance_of Instana::Exporter::Otlp::BaseConverter::SpanData, result
+    assert_equal 0, result.total_recorded_events
+    assert_equal [], result.events
+  end
+
+  def test_exception_event_has_no_message_when_no_error_field
+    span = create_test_span(name: :rack)
+    span[:stack] = [{ c: '/app/lib/client.rb', n: '7', m: 'in `call`' }]
+    span[:ec] = 1
+    converter = TestConverter.new(span)
+    events = converter.send(:build_error_events, span[:ec].to_i, converter.send(:extract_error_message), converter.send(:convert_stack_trace))
+
+    assert_equal 1, events.size
+    event = events.first
+    assert_equal 'exception', event.name
+    refute event.attributes.key?('exception.message')
+    assert event.attributes.key?('exception.stacktrace')
+  end
+
+  def test_convert_status_description_contains_error_message
+    span = create_test_span(name: :rack, data: { http: { error: 'Server error' } })
+    span[:ec] = 1
+    converter = TestConverter.new(span)
+    status = converter.send(:build_status, span[:ec].to_i, converter.send(:extract_error_message))
+    assert_equal 'Server error', status.description
+  end
+
+  def test_span_attributes_do_not_contain_exception_keys
+    # exception.* belong on events, NOT on span attributes
+    span = create_test_span(name: :rack, data: { http: { error: 'Timeout' } })
+    span[:stack] = [{ c: '/app/lib/client.rb', n: '7', m: 'in `call`' }]
+    span[:ec] = 1
+    converter = TestConverter.new(span)
+    result = converter.convert
+
+    refute result.attributes.key?('exception.stacktrace')
+    refute result.attributes.key?('exception.message')
+  end
+
   def test_convert_attributes
-    # Test empty attributes for base converter
+    # Test empty attributes for base converter (no stack)
     span = create_test_span(data: { undefined: { method: 'GET', url: 'http://example.com' } })
     converter = TestConverter.new(span)
     attributes = converter.send(:convert_attributes)
@@ -174,10 +329,19 @@ class BaseConverterTest < Minitest::Test
     span
   end
 
+  def create_error_span(name: :rack, error_msg: nil, stack: nil)
+    span = create_test_span(name: name)
+    span[:ec] = 1
+    span[:data] = { http: { error: error_msg } } if error_msg
+    span[:stack] = stack if stack
+    span
+  end
+
   # Test converter class that exposes protected methods for testing
   class TestConverter < Instana::Exporter::Otlp::BaseConverter
     # Make protected methods public for testing
     public :convert_span_kind, :convert_to_unix_nano,
-           :convert_status, :convert_attributes, :normalize_attribute_value, :span
+           :build_status, :convert_attributes, :normalize_attribute_value, :span,
+           :extract_error_message, :convert_stack_trace, :build_error_events
   end
 end

--- a/test/exporter/otlp/custom_converter_test.rb
+++ b/test/exporter/otlp/custom_converter_test.rb
@@ -44,4 +44,28 @@ class CustomConverterTest < Minitest::Test
     assert_equal 'value1', attributes['param1']
     assert_equal 42, attributes['param2']
   end
+
+  # --- span_name tests ---
+
+  def test_span_name_uses_sdk_name
+    span = Instana::Span.new(:my_custom_span)
+    span[:data] = { sdk: { name: 'my-operation', type: 'custom' } }
+    span.close
+    result = Instana::Exporter::Otlp::CustomConverter.new(span).convert
+    assert_equal 'my-operation', result[:name]
+  end
+
+  def test_span_name_falls_back_to_span_name_when_no_sdk_name
+    # When no sdk[:name] is set, CustomConverter falls back to super
+    # (BaseConverter#span_name -> span.name.to_s). For an unregistered
+    # span Instana stores the original name in sdk[:name] — so we must
+    # not override it. Here we simulate a span where sdk[:name] is nil
+    # so span.name returns nil and the result is an empty string.
+    span = Instana::Span.new(:my_custom_span)
+    # Overwrite sdk[:name] with nil to test the nil-name branch
+    span[:data][:sdk][:name] = nil
+    span.close
+    result = Instana::Exporter::Otlp::CustomConverter.new(span).convert
+    assert_equal '', result[:name]
+  end
 end

--- a/test/exporter/otlp/database_converter_test.rb
+++ b/test/exporter/otlp/database_converter_test.rb
@@ -113,6 +113,44 @@ class DatabaseConverterTest < Minitest::Test
     assert_empty attrs
   end
 
+  # --- span_name tests ---
+
+  def test_span_name_activerecord
+    span = create_span(:activerecord, { activerecord: { adapter: 'postgresql', db: 'mydb' } })
+    result = Instana::Exporter::Otlp::DatabaseConverter.new(span).convert
+    assert_equal 'postgresql mydb', result[:name]
+  end
+
+  def test_span_name_sequel
+    span = create_span(:sequel, { sequel: { adapter: 'mysql2', db: 'testdb' } })
+    result = Instana::Exporter::Otlp::DatabaseConverter.new(span).convert
+    assert_equal 'mysql2 testdb', result[:name]
+  end
+
+  def test_span_name_redis
+    span = create_span(:redis, { redis: { command: 'GET key', db: 0, connection: 'redis.local:6379' } })
+    result = Instana::Exporter::Otlp::DatabaseConverter.new(span).convert
+    assert_equal 'redis GET key', result[:name]
+  end
+
+  def test_span_name_memcache
+    span = create_span(:memcache, { memcache: { command: 'get', key: 'u:1', server: '127.0.0.1:11211' } })
+    result = Instana::Exporter::Otlp::DatabaseConverter.new(span).convert
+    assert_equal 'memcached get', result[:name]
+  end
+
+  def test_span_name_mongo
+    span = create_span(:mongo, { mongo: { namespace: 'users', command: 'find', peer: { hostname: 'localhost', port: 27017 } } })
+    result = Instana::Exporter::Otlp::DatabaseConverter.new(span).convert
+    assert_equal 'users.find', result[:name]
+  end
+
+  def test_span_name_falls_back_to_span_n_when_no_data
+    span = create_span(:activerecord, {})
+    result = Instana::Exporter::Otlp::DatabaseConverter.new(span).convert
+    assert_equal 'activerecord', result[:name]
+  end
+
   private
 
   def create_span(name, data)

--- a/test/exporter/otlp/graphql_converter_test.rb
+++ b/test/exporter/otlp/graphql_converter_test.rb
@@ -59,6 +59,27 @@ class GraphqlConverterTest < Minitest::Test
     assert_empty attrs
   end
 
+  # --- span_name tests ---
+
+  def test_span_name_with_type_and_name
+    span = create_span({ operationType: 'query', operationName: 'GetUser' })
+    result = Instana::Exporter::Otlp::GraphqlConverter.new(span).convert
+    assert_equal 'query GetUser', result[:name]
+  end
+
+  def test_span_name_with_type_only
+    span = create_span({ operationType: 'mutation' })
+    result = Instana::Exporter::Otlp::GraphqlConverter.new(span).convert
+    assert_equal 'mutation', result[:name]
+  end
+
+  def test_span_name_falls_back_to_graphql_when_no_data
+    span = Instana::Span.new(:graphql)
+    span.close
+    result = Instana::Exporter::Otlp::GraphqlConverter.new(span).convert
+    assert_equal 'graphql', result[:name]
+  end
+
   def test_format_fields
     span = create_span({})
     converter = Instana::Exporter::Otlp::GraphqlConverter.new(span)

--- a/test/exporter/otlp/http_converter_test.rb
+++ b/test/exporter/otlp/http_converter_test.rb
@@ -33,7 +33,7 @@ class HttpConverterTest < Minitest::Test
     assert_equal format_trace_id(span.trace_id), result[:trace_id]
     assert_equal format_span_id(span.id), result[:span_id]
     assert_equal format_span_id(span.parent_id), result[:parent_span_id]
-    assert_equal 'nethttp', result[:name]
+    assert_equal 'GET /users/123', result[:name]
     assert_equal :client, result[:kind] # CLIENT kind
 
     # Verify HTTP attributes are present (using new semantic conventions)
@@ -218,10 +218,10 @@ class HttpConverterTest < Minitest::Test
     result = converter.convert
 
     # Verify error status
-    assert_equal OpenTelemetry::Trace::Status::ERROR, result[:status].code # ERROR code
+    assert_equal OpenTelemetry::Trace::Status::ERROR, result.status.code # ERROR code
 
     # Verify HTTP attributes are still present
-    attributes = result[:attributes]
+    attributes = result.attributes
     assert_http_attribute(attributes, 'http.request.method', 'GET')
     assert_http_attribute(attributes, 'http.response.status_code', 500)
   end
@@ -288,6 +288,32 @@ class HttpConverterTest < Minitest::Test
     assert_http_attribute(results[0][:attributes], 'http.request.method', 'GET')
     assert_http_attribute(results[1][:attributes], 'http.request.method', 'POST')
     assert_http_attribute(results[2][:attributes], 'http.request.method', 'DELETE')
+  end
+
+  # --- span_name tests ---
+
+  def test_span_name_method_only
+    span = create_http_span(method: 'DELETE')
+    result = Instana::Exporter::Otlp::HttpConverter.new(span).convert
+    assert_equal 'DELETE', result[:name]
+  end
+
+  def test_span_name_method_and_path
+    span = create_http_span(method: 'GET', path: '/users/{id}')
+    result = Instana::Exporter::Otlp::HttpConverter.new(span).convert
+    assert_equal 'GET /users/{id}', result[:name]
+  end
+
+  def test_span_name_falls_back_to_http_when_no_method
+    span = create_http_span(method: nil)
+    result = Instana::Exporter::Otlp::HttpConverter.new(span).convert
+    assert_equal 'HTTP', result[:name]
+  end
+
+  def test_span_name_no_path_suffix_when_path_blank
+    span = create_http_span(method: 'POST', path: '')
+    result = Instana::Exporter::Otlp::HttpConverter.new(span).convert
+    assert_equal 'POST', result[:name]
   end
 
   private

--- a/test/exporter/otlp/messaging_converter_test.rb
+++ b/test/exporter/otlp/messaging_converter_test.rb
@@ -54,6 +54,32 @@ class MessagingConverterTest < Minitest::Test
     assert_empty attrs
   end
 
+  # --- span_name tests ---
+
+  def test_span_name_publish_uses_exchange
+    span = create_span(:rabbitmq, { rabbitmq: { exchange: 'orders', queue: 'order_queue', sort: 'publish' } })
+    result = Instana::Exporter::Otlp::MessagingConverter.new(span).convert
+    assert_equal 'orders publish', result[:name]
+  end
+
+  def test_span_name_publish_falls_back_to_queue_when_no_exchange
+    span = create_span(:rabbitmq, { rabbitmq: { queue: 'order_queue', sort: 'publish' } })
+    result = Instana::Exporter::Otlp::MessagingConverter.new(span).convert
+    assert_equal 'order_queue publish', result[:name]
+  end
+
+  def test_span_name_receive_uses_queue
+    span = create_span(:rabbitmq, { rabbitmq: { exchange: 'events', queue: 'events_q', sort: 'consume' } })
+    result = Instana::Exporter::Otlp::MessagingConverter.new(span).convert
+    assert_equal 'events_q receive', result[:name]
+  end
+
+  def test_span_name_falls_back_to_receive_when_no_queue
+    span = create_span(:rabbitmq, { rabbitmq: { sort: 'consume' } })
+    result = Instana::Exporter::Otlp::MessagingConverter.new(span).convert
+    assert_equal 'receive', result[:name]
+  end
+
   private
 
   def create_span(name, data)

--- a/test/exporter/otlp/rails_converter_test.rb
+++ b/test/exporter/otlp/rails_converter_test.rb
@@ -73,6 +73,38 @@ class RailsConverterTest < Minitest::Test
     assert_empty attrs
   end
 
+  # --- span_name tests ---
+
+  def test_span_name_actioncontroller
+    span = create_span('actioncontroller', { actioncontroller: { controller: 'UsersController', action: 'index' } })
+    result = Instana::Exporter::Otlp::RailsConverter.new(span).convert
+    assert_equal 'UsersController#index', result[:name]
+  end
+
+  def test_span_name_actionview
+    span = create_span('actionview', { actionview: { name: 'users/index.html.erb' } })
+    result = Instana::Exporter::Otlp::RailsConverter.new(span).convert
+    assert_equal 'users/index.html.erb', result[:name]
+  end
+
+  def test_span_name_render
+    span = create_span('render', { render: { type: 'partial', name: '_user.html.erb' } })
+    result = Instana::Exporter::Otlp::RailsConverter.new(span).convert
+    assert_equal 'partial _user.html.erb', result[:name]
+  end
+
+  def test_span_name_actionmailer
+    span = create_span('mail.actionmailer', { actionmailer: { class: 'UserMailer', method: 'welcome_email' } })
+    result = Instana::Exporter::Otlp::RailsConverter.new(span).convert
+    assert_equal 'UserMailer#welcome_email', result[:name]
+  end
+
+  def test_span_name_falls_back_to_span_n_for_unknown_type
+    span = create_span('unknown', {})
+    result = Instana::Exporter::Otlp::RailsConverter.new(span).convert
+    assert_equal 'unknown', result[:name]
+  end
+
   private
 
   def create_span(name, data)

--- a/test/exporter/otlp/rpc_converter_test.rb
+++ b/test/exporter/otlp/rpc_converter_test.rb
@@ -77,6 +77,37 @@ class RpcConverterTest < Minitest::Test
     assert_empty attrs
   end
 
+  # --- span_name tests ---
+
+  def test_span_name_grpc_strips_leading_slash
+    span = create_span(:grpc, { rpc: { call: '/package.Service/Method', host: 'grpc.example.com' } })
+    result = Instana::Exporter::Otlp::RpcConverter.new(span).convert
+    assert_equal 'package.Service/Method', result[:name]
+  end
+
+  def test_span_name_grpc_without_leading_slash
+    span = create_span(:grpc, { rpc: { call: 'pkg.API/Get' } })
+    result = Instana::Exporter::Otlp::RpcConverter.new(span).convert
+    assert_equal 'pkg.API/Get', result[:name]
+  end
+
+  def test_span_name_actioncable_with_action
+    span = create_span(:actioncable, { rpc: { flavor: :actioncable, call: 'ChatChannel#speak' } })
+    result = Instana::Exporter::Otlp::RpcConverter.new(span).convert
+    assert_equal 'ChatChannel#speak', result[:name]
+  end
+
+  def test_span_name_falls_back_to_span_name_when_call_missing
+    # :grpc is unregistered so Instana stores the original name in sdk[:name].
+    # We must not overwrite :data (which would lose sdk[:name]), so we
+    # build the span manually and only add the rpc sub-hash.
+    span = Instana::Span.new(:grpc)
+    span[:data][:rpc] = {}
+    span.close
+    result = Instana::Exporter::Otlp::RpcConverter.new(span).convert
+    assert_equal 'grpc', result[:name]
+  end
+
   private
 
   def create_span(name, data)


### PR DESCRIPTION
## Summary
Each instrumentation converter now overrides `span_name` to produce
OTel-compliant span names instead of the raw `span[:n]` key.

## Changes

| Converter | Span name format |
|---|---|
| **HTTP** | `METHOD path` (e.g. `GET /users`) |
| **AWS** | `queue/topic operation` for SQS/SNS, `DynamoDB.op` for DDB |
| **Background Job** | `queue process/publish` |
| **Custom (SDK)** | `span[:data][:sdk][:name]` |
| **Database** | `adapter db` for ActiveRecord/Sequel, `redis CMD`, `memcache CMD` |
| **GraphQL** | `operationType operationName` |
| **gRPC** | RPC call path (leading `/` stripped) |
| **Messaging** | `exchange/queue publish/receive` for RabbitMQ |
| **Rails** | `Controller#action`, `actionview name`, `render type name`, etc. |
| **RPC** | `rpc.call` (ActionCable preserves leading `/`) |

All converters fall back to `super` (the base `span[:n]` string) when
no meaningful name can be constructed. Tests extended accordingly.