### PR TITLE
fix(rack): always detach OTel context token after request

### DIFF
--- a/lib/instana/instrumentation/rack.rb
+++ b/lib/instana/instrumentation/rack.rb
@@ -34,6 +34,7 @@ module Instana
       raise
     ensure
       finalize_trace(current_span, kvs, headers, trace_context) if ::Instana.tracer.tracing?
+      OpenTelemetry::Context.detach(@trace_token) if @trace_token
     end
 
     private
@@ -123,7 +124,6 @@ module Instana
     def finalize_trace(current_span, kvs, headers, trace_context)
       set_response_headers(headers, trace_context) if headers
       current_span.add_attributes(kvs)
-      OpenTelemetry::Context.detach(@trace_token) if @trace_token
       current_span.finish
     end
 


### PR DESCRIPTION
`OpenTelemetry::Context.detach(@trace_token)` was previously called
inside `finalize_trace`, which is only invoked when
`::Instana.tracer.tracing?` is true. When tracing is disabled or
suppressed, the token attached in `call` was never detached, leaving
the OTel context stack in a corrupted state for subsequent requests on
the same thread.

Move the detach call directly into the `ensure` block of `call` so it
runs unconditionally, matching the lifecycle of `Context.attach`.