### PR TITLE
feat(configuration): Mark 4xx calls as erroneous spans and adapt current instrumentations

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -517,7 +517,7 @@ Metrics/BlockNesting:
 # Offense count: 19
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 298
+  Max: 321
 
 # Offense count: 15
 # Configuration parameters: IgnoredMethods.
@@ -532,7 +532,7 @@ Metrics/MethodLength:
 # Offense count: 1
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ModuleLength:
-  Max: 128
+  Max: 131
 
 # Offense count: 16
 # Configuration parameters: IgnoredMethods.

--- a/lib/instana/config.rb
+++ b/lib/instana/config.rb
@@ -80,6 +80,10 @@ module Instana
       # W3C Trace Context Support
       @config[:w3c_trace_correlation] = ENV.fetch('INSTANA_DISABLE_W3C_TRACE_CORRELATION', nil).nil?
 
+      # HTTP exit span 4xx error classification (opt-in, default: off)
+      # Priority: env vars > agent config > default (false / [])
+      read_http_exit_config
+
       @config[:post_fork_proc] = proc { ::Instana.agent.spawn_background_thread }
 
       @config[:action_controller]  = { :enabled => true }
@@ -142,6 +146,8 @@ module Instana
       read_span_stack_config_from_agent(tracing_config) if should_read_from_agent?(:back_trace)
       # Read OTLP configuration from agent if not already set from YAML or env
       read_otlp_config_from_agent(tracing_config) if should_read_from_agent?(:otlp)
+      # Read HTTP exit 4xx classification from agent if env vars did not already set it
+      read_http_exit_classification_from_agent(tracing_config) unless env_http_exit_classification_set?
       # Read span filtering configuration from agent
       ::Instana.span_filtering_config&.read_config_from_agent(discovery)
     rescue => e
@@ -255,6 +261,75 @@ module Instana
     end
 
     private
+
+    # Read HTTP exit 4xx error classification config (wrapper — same pattern as read_span_stack_config / read_otlp_config)
+    def read_http_exit_config
+      @config[:http_exit_classify_all_4xx_as_errors] = false
+      @config[:http_exit_classify_as_errors] = []
+      read_http_exit_classification_from_env
+    end
+
+    # Read HTTP exit 4xx classification from environment variables (highest priority).
+    def read_http_exit_classification_from_env
+      classify_codes_raw = ENV.fetch('INSTANA_TRACING_HTTP_EXIT_CLASSIFY_AS_ERRORS', nil)
+      if classify_codes_raw
+        codes = classify_codes_raw.split(',').filter_map do |part|
+          part = part.strip
+          if part.match?(/\A\d+\z/)
+            code = part.to_i
+            if (400..499).cover?(code)
+              code
+            else
+              msg = "Ignoring out-of-range value in INSTANA_TRACING_HTTP_EXIT_CLASSIFY_AS_ERRORS: #{code}, must be 400-499"
+              ::Instana.logger.warn(msg)
+              nil
+            end
+          elsif part != ''
+            ::Instana.logger.warn("Ignoring non-integer value in INSTANA_TRACING_HTTP_EXIT_CLASSIFY_AS_ERRORS: #{part}")
+            nil
+          end
+        end
+        @config[:http_exit_classify_as_errors] = codes unless codes.empty?
+      else
+        classify_all_raw = ENV.fetch('INSTANA_TRACING_HTTP_EXIT_CLASSIFY_ALL_4XX_AS_ERRORS', nil)
+        @config[:http_exit_classify_all_4xx_as_errors] = truthy?(classify_all_raw) if classify_all_raw
+      end
+    end
+
+    # Return true if env vars have already configured HTTP exit 4xx classification.
+    def env_http_exit_classification_set?
+      ENV.key?('INSTANA_TRACING_HTTP_EXIT_CLASSIFY_AS_ERRORS') ||
+        ENV.key?('INSTANA_TRACING_HTTP_EXIT_CLASSIFY_ALL_4XX_AS_ERRORS')
+    end
+
+    # Read HTTP exit 4xx classification from agent discovery response (lowest priority).
+    # @param tracing_config [Hash] the tracing sub-hash from the discovery payload
+    def read_http_exit_classification_from_agent(tracing_config)
+      http_cfg = tracing_config['http']
+      return unless http_cfg.is_a?(Hash)
+
+      exit_cfg = http_cfg['exit']
+      return unless exit_cfg.is_a?(Hash)
+
+      if exit_cfg.key?('classify-as-errors')
+        codes = Array(exit_cfg['classify-as-errors']).filter_map do |code|
+          if code.is_a?(Integer) && (400..499).cover?(code)
+            code
+          else
+            ::Instana.logger.warn("Ignoring invalid value in agent config tracing.http.exit.classify-as-errors: #{code}")
+            nil
+          end
+        end
+        @config[:http_exit_classify_as_errors] = codes unless codes.empty?
+      elsif exit_cfg.key?('classify-all-4xx-as-errors')
+        val = exit_cfg['classify-all-4xx-as-errors']
+        if [true, false].include?(val)
+          @config[:http_exit_classify_all_4xx_as_errors] = val
+        else
+          ::Instana.logger.warn("Ignoring non-boolean value in agent config tracing.http.exit.classify-all-4xx-as-errors: #{val}")
+        end
+      end
+    end
 
     # Read OTLP configuration — precedence: YAML > env vars > defaults (agent handled separately)
     def read_otlp_config

--- a/lib/instana/instrumentation/excon.rb
+++ b/lib/instana/instrumentation/excon.rb
@@ -1,6 +1,8 @@
 # (c) Copyright IBM Corp. 2021
 # (c) Copyright Instana Inc. 2016
 
+require 'instana/util'
+
 module Instana
   module Instrumentation
     class Excon < ::Excon::Middleware::Base
@@ -60,17 +62,18 @@ module Instana
           status = datum[:response][:status]
         end
 
-        if status >= 500
-          # Because of the 5xx response, we flag this span as errored but
-          # without a backtrace (no exception)
+        http_kv = { status: status }
+        if ::Instana::Util.should_mark_http_exit_as_error?(status)
+          reason = ::Instana::Util.http_reason_phrase(status)
+          http_kv[:error] = reason ? "#{status} #{reason}" : status.to_s
           ::Instana.tracer.log_error(nil)
         end
 
         if datum[:pipeline] == true
           # Pickup context of this async span from datum[:instana_span]
-          ::Instana.tracer.log_async_exit(:excon, { :http => {:status => status } }, datum[:instana_span])
+          ::Instana.tracer.log_async_exit(:excon, { :http => http_kv }, datum[:instana_span])
         else
-          ::Instana.tracer.log_exit(:excon, { :http => {:status => status } })
+          ::Instana.tracer.log_exit(:excon, { :http => http_kv })
         end
         result
       end

--- a/lib/instana/instrumentation/net-http.rb
+++ b/lib/instana/instrumentation/net-http.rb
@@ -2,6 +2,7 @@
 # (c) Copyright Instana Inc. 2016
 
 require 'net/http'
+require 'instana/util'
 
 module Instana
   module Instrumentation
@@ -51,9 +52,8 @@ module Instana
         response = super(*args, &block)
 
         kv_payload[:http][:status] = response.code
-        if response.code.to_i >= 500
-          # Because of the 5xx response, we flag this span as errored but
-          # without a backtrace (no exception)
+        if ::Instana::Util.should_mark_http_exit_as_error?(response.code.to_i)
+          kv_payload[:http][:error] = "#{response.code} #{response.message}"
           current_span.record_exception(nil)
         end
         extra_headers = ::Instana::Util.extra_header_tags(response)&.merge(::Instana::Util.extra_header_tags(request))

--- a/lib/instana/instrumentation/rest-client.rb
+++ b/lib/instana/instrumentation/rest-client.rb
@@ -1,6 +1,8 @@
 # (c) Copyright IBM Corp. 2021
 # (c) Copyright Instana Inc. 2016
 
+require 'instana/util'
+
 module Instana
   module Instrumentation
     module RestClientRequest
@@ -12,10 +14,20 @@ module Instana
 
         Trace.with_span(span) { super(&block) }
       rescue => e
-        span.record_exception(e)
+        span.record_exception(e) if error_span?(e)
         raise
       ensure
         span.finish
+      end
+
+      private
+
+      def error_span?(exception)
+        if exception.respond_to?(:response) && exception.response.respond_to?(:code)
+          ::Instana::Util.should_mark_http_exit_as_error?(exception.response.code.to_i)
+        else
+          true
+        end
       end
     end
   end

--- a/lib/instana/util.rb
+++ b/lib/instana/util.rb
@@ -194,6 +194,41 @@ module Instana
 
         headers
       end
+
+      # Return true if an HTTP exit span with +status_code+ should be marked as errored.
+      #
+      # Rules (in priority order):
+      # 1. status >= 500  → always an error.
+      # 2. 400 <= status <= 499 and +config[:http_exit_classify_as_errors]+ is non-empty
+      #    → error only if +status_code+ is in that list.
+      # 3. 400 <= status <= 499 and +config[:http_exit_classify_all_4xx_as_errors]+ is true
+      #    → error for every 4xx code.
+      # 4. Otherwise → not an error.
+      #
+      # Entry (server/rack) spans must never be passed here; this helper is for exit spans only.
+      def should_mark_http_exit_as_error?(status_code)
+        return true if status_code >= 500
+
+        if (400..499).cover?(status_code)
+          codes = ::Instana.config[:http_exit_classify_as_errors]
+          return codes.include?(status_code) if codes&.any?
+
+          return ::Instana.config[:http_exit_classify_all_4xx_as_errors]
+        end
+
+        false
+      end
+
+      # Return the HTTP reason phrase for a numeric status code, or nil if unknown.
+      # Uses Ruby stdlib Net::HTTPResponse::CODE_TO_OBJ to derive the phrase from
+      # the response class name (e.g. Net::HTTPUnauthorized → "Unauthorized").
+      def http_reason_phrase(status_code)
+        require 'net/http'
+        klass = Net::HTTPResponse::CODE_TO_OBJ[status_code.to_s]
+        return nil unless klass
+
+        klass.name.sub('Net::HTTP', '').gsub(/([A-Z])/, ' \1').strip
+      end
     end
   end
 end

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -1078,3 +1078,112 @@ class OtlpConfigTest < Minitest::Test
     refute subject.send(:should_read_from_agent?, :otlp)
   end
 end
+
+class HttpExitClassificationConfigTest < Minitest::Test
+  def logger
+    Logger.new('/dev/null')
+  end
+
+  # -------------------------------------------------------------------------
+  # Default values
+  # -------------------------------------------------------------------------
+
+  def test_defaults_are_off
+    subject = Instana::Config.new(logger: logger)
+    assert_equal false, subject[:http_exit_classify_all_4xx_as_errors]
+    assert_equal [],    subject[:http_exit_classify_as_errors]
+  end
+
+  # -------------------------------------------------------------------------
+  # Env var: INSTANA_TRACING_HTTP_EXIT_CLASSIFY_ALL_4XX_AS_ERRORS
+  # -------------------------------------------------------------------------
+
+  def test_env_classify_all_4xx_sets_flag
+    ENV['INSTANA_TRACING_HTTP_EXIT_CLASSIFY_ALL_4XX_AS_ERRORS'] = '1'
+    subject = Instana::Config.new(logger: logger)
+    assert_equal true, subject[:http_exit_classify_all_4xx_as_errors]
+    assert_equal [],   subject[:http_exit_classify_as_errors]
+  ensure
+    ENV.delete('INSTANA_TRACING_HTTP_EXIT_CLASSIFY_ALL_4XX_AS_ERRORS')
+  end
+
+  # -------------------------------------------------------------------------
+  # Env var: INSTANA_TRACING_HTTP_EXIT_CLASSIFY_AS_ERRORS
+  # -------------------------------------------------------------------------
+
+  def test_env_classify_as_errors_parses_csv
+    ENV['INSTANA_TRACING_HTTP_EXIT_CLASSIFY_AS_ERRORS'] = '401,404,429'
+    subject = Instana::Config.new(logger: logger)
+    assert_equal [401, 404, 429], subject[:http_exit_classify_as_errors]
+    assert_equal false,           subject[:http_exit_classify_all_4xx_as_errors]
+  ensure
+    ENV.delete('INSTANA_TRACING_HTTP_EXIT_CLASSIFY_AS_ERRORS')
+  end
+
+  def test_env_classify_as_errors_ignores_out_of_range_codes
+    ENV['INSTANA_TRACING_HTTP_EXIT_CLASSIFY_AS_ERRORS'] = '401,500,200'
+    subject = Instana::Config.new(logger: logger)
+    assert_equal [401], subject[:http_exit_classify_as_errors]
+  ensure
+    ENV.delete('INSTANA_TRACING_HTTP_EXIT_CLASSIFY_AS_ERRORS')
+  end
+
+  def test_env_classify_as_errors_ignores_non_integer_values
+    ENV['INSTANA_TRACING_HTTP_EXIT_CLASSIFY_AS_ERRORS'] = '401,foo,404'
+    subject = Instana::Config.new(logger: logger)
+    assert_equal [401, 404], subject[:http_exit_classify_as_errors]
+  ensure
+    ENV.delete('INSTANA_TRACING_HTTP_EXIT_CLASSIFY_AS_ERRORS')
+  end
+
+  def test_env_classify_as_errors_takes_priority_over_classify_all
+    ENV['INSTANA_TRACING_HTTP_EXIT_CLASSIFY_AS_ERRORS'] = '401'
+    ENV['INSTANA_TRACING_HTTP_EXIT_CLASSIFY_ALL_4XX_AS_ERRORS'] = '1'
+    subject = Instana::Config.new(logger: logger)
+    assert_equal [401], subject[:http_exit_classify_as_errors]
+    assert_equal false, subject[:http_exit_classify_all_4xx_as_errors]
+  ensure
+    ENV.delete('INSTANA_TRACING_HTTP_EXIT_CLASSIFY_AS_ERRORS')
+    ENV.delete('INSTANA_TRACING_HTTP_EXIT_CLASSIFY_ALL_4XX_AS_ERRORS')
+  end
+
+  # -------------------------------------------------------------------------
+  # Agent config (lowest priority)
+  # -------------------------------------------------------------------------
+
+  def test_agent_config_classify_all_4xx
+    subject = Instana::Config.new(logger: logger)
+    subject.read_config_from_agent('tracing' => {
+                                     'http' => { 'exit' => { 'classify-all-4xx-as-errors' => true } }
+                                   })
+    assert_equal true, subject[:http_exit_classify_all_4xx_as_errors]
+  end
+
+  def test_agent_config_classify_as_errors
+    subject = Instana::Config.new(logger: logger)
+    subject.read_config_from_agent('tracing' => {
+                                     'http' => { 'exit' => { 'classify-as-errors' => [401, 429] } }
+                                   })
+    assert_equal [401, 429], subject[:http_exit_classify_as_errors]
+  end
+
+  def test_agent_config_ignored_when_env_var_already_set
+    ENV['INSTANA_TRACING_HTTP_EXIT_CLASSIFY_ALL_4XX_AS_ERRORS'] = '1'
+    subject = Instana::Config.new(logger: logger)
+    # Agent says false — env var must win
+    subject.read_config_from_agent('tracing' => {
+                                     'http' => { 'exit' => { 'classify-all-4xx-as-errors' => false } }
+                                   })
+    assert_equal true, subject[:http_exit_classify_all_4xx_as_errors]
+  ensure
+    ENV.delete('INSTANA_TRACING_HTTP_EXIT_CLASSIFY_ALL_4XX_AS_ERRORS')
+  end
+
+  def test_agent_config_ignores_invalid_codes
+    subject = Instana::Config.new(logger: logger)
+    subject.read_config_from_agent('tracing' => {
+                                     'http' => { 'exit' => { 'classify-as-errors' => [401, 500, 'bad'] } }
+                                   })
+    assert_equal [401], subject[:http_exit_classify_as_errors]
+  end
+end

--- a/test/instrumentation/excon_test.rb
+++ b/test/instrumentation/excon_test.rb
@@ -107,7 +107,8 @@ class ExconTest < Minitest::Test
       Instana.tracer.in_span('excon-test') do
         connection.get(:path => '/error')
       end
-    rescue
+    rescue StandardError
+      nil
     end
 
     spans = ::Instana.processor.queued_spans
@@ -225,5 +226,104 @@ class ExconTest < Minitest::Test
 
     assert_nil error
     assert_empty ::Instana.processor.queued_spans
+  end
+end
+
+class Excon4xxClassificationTest < Minitest::Test
+  include Instana::TestHelpers
+
+  def setup
+    @orig_classify_all   = ::Instana.config[:http_exit_classify_all_4xx_as_errors]
+    @orig_classify_codes = ::Instana.config[:http_exit_classify_as_errors]
+    Excon.defaults[:middlewares].delete(::WebMock::HttpLibAdapters::ExconAdapter)
+    Excon.defaults[:middlewares].delete(::Excon::Middleware::Mock)
+  end
+
+  def teardown
+    ::Instana.config[:http_exit_classify_all_4xx_as_errors] = @orig_classify_all
+    ::Instana.config[:http_exit_classify_as_errors]         = @orig_classify_codes
+  end
+
+  def test_4xx_not_an_error_by_default
+    clear_all!
+    ::Instana.config[:http_exit_classify_all_4xx_as_errors] = false
+    ::Instana.config[:http_exit_classify_as_errors]         = []
+
+    Instana.tracer.in_span(:'excon-4xx-test') do
+      Excon.get('http://127.0.0.1:6511/status/401')
+    end
+
+    spans      = ::Instana.processor.queued_spans
+    excon_span = find_first_span_by_name(spans, :excon)
+
+    assert_nil excon_span[:error]
+    assert_nil excon_span[:ec]
+    assert_equal 401, excon_span[:data][:http][:status]
+  end
+
+  def test_4xx_is_error_when_classify_all_is_true
+    clear_all!
+    ::Instana.config[:http_exit_classify_all_4xx_as_errors] = true
+    ::Instana.config[:http_exit_classify_as_errors]         = []
+
+    Instana.tracer.in_span(:'excon-4xx-test') do
+      Excon.get('http://127.0.0.1:6511/status/401')
+    end
+
+    spans      = ::Instana.processor.queued_spans
+    excon_span = find_first_span_by_name(spans, :excon)
+
+    assert_equal true,          excon_span[:error]
+    assert_equal 1,             excon_span[:ec]
+    assert_equal '401 Unauthorized', excon_span[:data][:http][:error]
+  end
+
+  def test_listed_4xx_code_is_error
+    clear_all!
+    ::Instana.config[:http_exit_classify_all_4xx_as_errors] = false
+    ::Instana.config[:http_exit_classify_as_errors]         = [401]
+
+    Instana.tracer.in_span(:'excon-4xx-test') do
+      Excon.get('http://127.0.0.1:6511/status/401')
+    end
+
+    spans      = ::Instana.processor.queued_spans
+    excon_span = find_first_span_by_name(spans, :excon)
+
+    assert_equal true,          excon_span[:error]
+    assert_equal 1,             excon_span[:ec]
+    assert_equal '401 Unauthorized', excon_span[:data][:http][:error]
+  end
+
+  def test_unlisted_4xx_code_is_not_error
+    clear_all!
+    ::Instana.config[:http_exit_classify_all_4xx_as_errors] = false
+    ::Instana.config[:http_exit_classify_as_errors]         = [401]
+
+    Instana.tracer.in_span(:'excon-4xx-test') do
+      Excon.get('http://127.0.0.1:6511/status/404')
+    end
+
+    spans      = ::Instana.processor.queued_spans
+    excon_span = find_first_span_by_name(spans, :excon)
+
+    assert_nil excon_span[:error]
+    assert_nil excon_span[:ec]
+  end
+
+  def test_5xx_still_errors_regardless_of_config
+    clear_all!
+    ::Instana.config[:http_exit_classify_all_4xx_as_errors] = false
+    ::Instana.config[:http_exit_classify_as_errors]         = []
+
+    Instana.tracer.in_span(:'excon-4xx-test') do
+      Excon.get('http://127.0.0.1:6511/error')
+    end
+
+    spans      = ::Instana.processor.queued_spans
+    excon_span = find_first_span_by_name(spans, :excon)
+
+    assert_equal true, excon_span[:error]
+    assert_equal 1,    excon_span[:ec]
   end
 end

--- a/test/instrumentation/net_http_test.rb
+++ b/test/instrumentation/net_http_test.rb
@@ -75,10 +75,9 @@ class NetHTTPTest < Minitest::Test
     uri = URI.parse(url)
     req = Net::HTTP::Get.new(uri)
 
-    response = nil
     Instana.tracer.in_span('net-http-test') do
       Net::HTTP.start(req.uri.hostname, req.uri.port, :open_timeout => 1, :read_timeout => 1) do |http|
-        response = http.request(req)
+        http.request(req)
       end
     end
 
@@ -117,10 +116,9 @@ class NetHTTPTest < Minitest::Test
     clear_all!
     WebMock.allow_net_connect!
 
-    response = nil
     Instana.tracer.in_span('net-http-test') do
       http = Net::HTTP.new("127.0.0.1", 6511)
-      response = http.request(Net::HTTP::Post.new("/"))
+      http.request(Net::HTTP::Post.new("/"))
     end
 
     spans = ::Instana.processor.queued_spans
@@ -188,16 +186,14 @@ class NetHTTPTest < Minitest::Test
     clear_all!
     WebMock.allow_net_connect!
 
-    response = nil
     Instana.tracer.in_span('net-http-error-test') do
       http = Net::HTTP.new("127.0.0.1", 6511)
-      response = http.request(Net::HTTP::Get.new("/error"))
+      http.request(Net::HTTP::Get.new("/error"))
     end
 
     spans = ::Instana.processor.queued_spans
     assert_equal 3, spans.length
 
-    rack_span = find_first_span_by_name(spans, :rack)
     sdk_span = find_first_span_by_name(spans, :'net-http-error-test')
     http_span = find_first_span_by_name(spans, :'net-http')
 
@@ -235,5 +231,108 @@ class NetHTTPTest < Minitest::Test
     assert_empty ::Instana.processor.queued_spans
 
     WebMock.disable_net_connect!
+  end
+end
+
+class NetHTTP4xxClassificationTest < Minitest::Test
+  include Instana::TestHelpers
+
+  def setup
+    @orig_classify_all   = ::Instana.config[:http_exit_classify_all_4xx_as_errors]
+    @orig_classify_codes = ::Instana.config[:http_exit_classify_as_errors]
+  end
+
+  def teardown
+    ::Instana.config[:http_exit_classify_all_4xx_as_errors] = @orig_classify_all
+    ::Instana.config[:http_exit_classify_as_errors]         = @orig_classify_codes
+    WebMock.disable_net_connect!
+  end
+
+  def test_4xx_not_an_error_by_default
+    clear_all!
+    WebMock.allow_net_connect!
+    ::Instana.config[:http_exit_classify_all_4xx_as_errors] = false
+    ::Instana.config[:http_exit_classify_as_errors]         = []
+
+    Instana.tracer.in_span(:'net-http-4xx-test') do
+      Net::HTTP.get_response(URI('http://127.0.0.1:6511/status/401'))
+    end
+
+    spans = ::Instana.processor.queued_spans
+    http_span = find_first_span_by_name(spans, :'net-http')
+
+    assert_nil http_span[:error]
+    assert_nil http_span[:ec]
+    assert_equal '401', http_span[:data][:http][:status]
+  end
+
+  def test_4xx_is_error_when_classify_all_is_true
+    clear_all!
+    WebMock.allow_net_connect!
+    ::Instana.config[:http_exit_classify_all_4xx_as_errors] = true
+    ::Instana.config[:http_exit_classify_as_errors]         = []
+
+    Instana.tracer.in_span(:'net-http-4xx-test') do
+      Net::HTTP.get_response(URI('http://127.0.0.1:6511/status/401'))
+    end
+
+    spans     = ::Instana.processor.queued_spans
+    http_span = find_first_span_by_name(spans, :'net-http')
+
+    assert_equal true, http_span[:error]
+    assert_equal 1,    http_span[:ec]
+    assert_match(/\A401 /, http_span[:data][:http][:error], 'http.error must start with status code')
+  end
+
+  def test_listed_4xx_code_is_error
+    clear_all!
+    WebMock.allow_net_connect!
+    ::Instana.config[:http_exit_classify_all_4xx_as_errors] = false
+    ::Instana.config[:http_exit_classify_as_errors]         = [401]
+
+    Instana.tracer.in_span(:'net-http-4xx-test') do
+      Net::HTTP.get_response(URI('http://127.0.0.1:6511/status/401'))
+    end
+
+    spans     = ::Instana.processor.queued_spans
+    http_span = find_first_span_by_name(spans, :'net-http')
+
+    assert_equal true, http_span[:error]
+    assert_equal 1,    http_span[:ec]
+    assert_match(/\A401 /, http_span[:data][:http][:error], 'http.error must start with status code')
+  end
+
+  def test_unlisted_4xx_code_is_not_error
+    clear_all!
+    WebMock.allow_net_connect!
+    ::Instana.config[:http_exit_classify_all_4xx_as_errors] = false
+    ::Instana.config[:http_exit_classify_as_errors]         = [401]
+
+    Instana.tracer.in_span(:'net-http-4xx-test') do
+      Net::HTTP.get_response(URI('http://127.0.0.1:6511/status/404'))
+    end
+
+    spans     = ::Instana.processor.queued_spans
+    http_span = find_first_span_by_name(spans, :'net-http')
+
+    assert_nil http_span[:error]
+    assert_nil http_span[:ec]
+  end
+
+  def test_5xx_still_errors_regardless_of_config
+    clear_all!
+    WebMock.allow_net_connect!
+    ::Instana.config[:http_exit_classify_all_4xx_as_errors] = false
+    ::Instana.config[:http_exit_classify_as_errors]         = []
+
+    Instana.tracer.in_span(:'net-http-4xx-test') do
+      Net::HTTP.get_response(URI('http://127.0.0.1:6511/error'))
+    end
+
+    spans     = ::Instana.processor.queued_spans
+    http_span = find_first_span_by_name(spans, :'net-http')
+
+    assert_equal true, http_span[:error]
+    assert_equal 1,    http_span[:ec]
   end
 end

--- a/test/instrumentation/rest_client_test.rb
+++ b/test/instrumentation/rest_client_test.rb
@@ -125,3 +125,98 @@ class RestClientTest < Minitest::Test
     WebMock.disable_net_connect!
   end
 end
+
+class RestClient4xxClassificationTest < Minitest::Test
+  include Instana::TestHelpers
+
+  def setup
+    @orig_classify_all   = ::Instana.config[:http_exit_classify_all_4xx_as_errors]
+    @orig_classify_codes = ::Instana.config[:http_exit_classify_as_errors]
+  end
+
+  def teardown
+    ::Instana.config[:http_exit_classify_all_4xx_as_errors] = @orig_classify_all
+    ::Instana.config[:http_exit_classify_as_errors]         = @orig_classify_codes
+    WebMock.disable_net_connect!
+  end
+
+  # Helper: fire a RestClient GET, swallowing ExceptionWithResponse so the
+  # test can inspect spans regardless of whether RestClient raised.
+  def get_ignoring_http_errors(url)
+    RestClient.get(url)
+  rescue RestClient::ExceptionWithResponse
+    nil
+  end
+
+  def test_4xx_rest_client_span_not_errored_by_default
+    clear_all!
+    WebMock.allow_net_connect!
+    ::Instana.config[:http_exit_classify_all_4xx_as_errors] = false
+    ::Instana.config[:http_exit_classify_as_errors]         = []
+
+    Instana.tracer.in_span(:'restclient-4xx-test') do
+      get_ignoring_http_errors('http://127.0.0.1:6511/status/401')
+    end
+
+    spans = ::Instana.processor.queued_spans
+    rc_span   = find_first_span_by_name(spans, :'rest-client')
+    http_span = find_first_span_by_name(spans, :'net-http')
+
+    assert_nil rc_span[:error],   'rest-client span must not be errored in default mode'
+    assert_nil http_span[:error], 'net-http span must not be errored in default mode'
+  end
+
+  def test_4xx_both_spans_errored_when_classify_all_is_true
+    clear_all!
+    WebMock.allow_net_connect!
+    ::Instana.config[:http_exit_classify_all_4xx_as_errors] = true
+    ::Instana.config[:http_exit_classify_as_errors]         = []
+
+    Instana.tracer.in_span(:'restclient-4xx-test') do
+      get_ignoring_http_errors('http://127.0.0.1:6511/status/401')
+    end
+
+    spans = ::Instana.processor.queued_spans
+    rc_span   = find_first_span_by_name(spans, :'rest-client')
+    http_span = find_first_span_by_name(spans, :'net-http')
+
+    assert_equal true, rc_span[:error],   'rest-client span must be errored'
+    assert_equal true, http_span[:error], 'net-http span must be errored'
+  end
+
+  def test_listed_code_errors_both_spans
+    clear_all!
+    WebMock.allow_net_connect!
+    ::Instana.config[:http_exit_classify_all_4xx_as_errors] = false
+    ::Instana.config[:http_exit_classify_as_errors]         = [401]
+
+    Instana.tracer.in_span(:'restclient-4xx-test') do
+      get_ignoring_http_errors('http://127.0.0.1:6511/status/401')
+    end
+
+    spans = ::Instana.processor.queued_spans
+    rc_span   = find_first_span_by_name(spans, :'rest-client')
+    http_span = find_first_span_by_name(spans, :'net-http')
+
+    assert_equal true, rc_span[:error]
+    assert_equal true, http_span[:error]
+  end
+
+  def test_unlisted_code_does_not_error_either_span
+    clear_all!
+    WebMock.allow_net_connect!
+    ::Instana.config[:http_exit_classify_all_4xx_as_errors] = false
+    ::Instana.config[:http_exit_classify_as_errors]         = [401]
+
+    Instana.tracer.in_span(:'restclient-4xx-test') do
+      get_ignoring_http_errors('http://127.0.0.1:6511/status/404')
+    end
+
+    spans = ::Instana.processor.queued_spans
+    rc_span   = find_first_span_by_name(spans, :'rest-client')
+    http_span = find_first_span_by_name(spans, :'net-http')
+
+    assert_nil rc_span[:error],   'rest-client span must not be errored for unlisted code'
+    assert_nil http_span[:error], 'net-http span must not be errored for unlisted code'
+  end
+end

--- a/test/instrumentation/sidekiq-client_test.rb
+++ b/test/instrumentation/sidekiq-client_test.rb
@@ -82,7 +82,8 @@ class SidekiqClientTest < Minitest::Test
           'args' => [1, 2, 3],
           'retry' => false
         )
-      rescue
+      rescue StandardError
+        nil
       end
       enable_redis_instrumentation
       remove_sidekiq_exception_middleware

--- a/test/support/apps/http_endpoint/boot.rb
+++ b/test/support/apps/http_endpoint/boot.rb
@@ -20,6 +20,14 @@ Thread.new do
         [500, {"Content-Type" => "application/json"}, ["[\"Stan\",\"is\",\"on\",\"the\",\"error!\"]"]]
       }
     end
+    # Returns any status code supplied as the last path segment, e.g. /status/401
+    map "/status" do
+      run Proc.new { |env|
+        code = env['PATH_INFO'].split('/').last.to_i
+        code = 200 if code < 100 || code > 599
+        [code, {"Content-Type" => "application/json"}, ["[\"status\",#{code}]"]]
+      }
+    end
   }
 
   Rackup::Handler::Puma.run(app, Host: '127.0.0.1', Port: 6511)

--- a/test/util_test.rb
+++ b/test/util_test.rb
@@ -4,7 +4,104 @@
 require 'test_helper'
 
 class UtilTest < Minitest::Test
+  include Instana::TestHelpers
+
+  def setup
+    @orig_classify_all = ::Instana.config[:http_exit_classify_all_4xx_as_errors]
+    @orig_classify_codes = ::Instana.config[:http_exit_classify_as_errors]
+  end
+
+  def teardown
+    ::Instana.config[:http_exit_classify_all_4xx_as_errors] = @orig_classify_all
+    ::Instana.config[:http_exit_classify_as_errors] = @orig_classify_codes
+  end
+
   def test_get_rb_source_error
     assert_equal({ error: "Only Ruby source files are allowed. (*.rb)" }, Instana::Util.get_rb_source('invalid.txt'))
+  end
+
+  # -------------------------------------------------------------------------
+  # Default behaviour — 4xx never an error, 5xx always an error
+  # -------------------------------------------------------------------------
+
+  def test_5xx_is_always_an_error_in_default_mode
+    ::Instana.config[:http_exit_classify_all_4xx_as_errors] = false
+    ::Instana.config[:http_exit_classify_as_errors] = []
+
+    assert ::Instana::Util.should_mark_http_exit_as_error?(500)
+    assert ::Instana::Util.should_mark_http_exit_as_error?(503)
+  end
+
+  def test_4xx_is_not_an_error_in_default_mode
+    ::Instana.config[:http_exit_classify_all_4xx_as_errors] = false
+    ::Instana.config[:http_exit_classify_as_errors] = []
+
+    refute ::Instana::Util.should_mark_http_exit_as_error?(400)
+    refute ::Instana::Util.should_mark_http_exit_as_error?(401)
+    refute ::Instana::Util.should_mark_http_exit_as_error?(404)
+    refute ::Instana::Util.should_mark_http_exit_as_error?(499)
+  end
+
+  def test_2xx_and_3xx_are_never_errors
+    ::Instana.config[:http_exit_classify_all_4xx_as_errors] = true
+    ::Instana.config[:http_exit_classify_as_errors] = []
+
+    refute ::Instana::Util.should_mark_http_exit_as_error?(200)
+    refute ::Instana::Util.should_mark_http_exit_as_error?(301)
+  end
+
+  # -------------------------------------------------------------------------
+  # classify_all_4xx mode
+  # -------------------------------------------------------------------------
+
+  def test_all_4xx_are_errors_when_classify_all_is_true
+    ::Instana.config[:http_exit_classify_all_4xx_as_errors] = true
+    ::Instana.config[:http_exit_classify_as_errors] = []
+
+    assert ::Instana::Util.should_mark_http_exit_as_error?(400)
+    assert ::Instana::Util.should_mark_http_exit_as_error?(401)
+    assert ::Instana::Util.should_mark_http_exit_as_error?(404)
+    assert ::Instana::Util.should_mark_http_exit_as_error?(429)
+    assert ::Instana::Util.should_mark_http_exit_as_error?(499)
+  end
+
+  # -------------------------------------------------------------------------
+  # classify specific codes mode
+  # -------------------------------------------------------------------------
+
+  def test_only_listed_codes_are_errors
+    ::Instana.config[:http_exit_classify_all_4xx_as_errors] = false
+    ::Instana.config[:http_exit_classify_as_errors] = [401, 404]
+
+    assert ::Instana::Util.should_mark_http_exit_as_error?(401)
+    assert ::Instana::Util.should_mark_http_exit_as_error?(404)
+    refute ::Instana::Util.should_mark_http_exit_as_error?(429)
+    refute ::Instana::Util.should_mark_http_exit_as_error?(400)
+  end
+
+  def test_classify_as_errors_takes_priority_over_classify_all
+    # When both are set, classify_as_errors list wins
+    ::Instana.config[:http_exit_classify_all_4xx_as_errors] = true
+    ::Instana.config[:http_exit_classify_as_errors] = [401]
+
+    assert ::Instana::Util.should_mark_http_exit_as_error?(401)
+    # 404 would match classify_all but the list takes priority → not listed → not an error
+    refute ::Instana::Util.should_mark_http_exit_as_error?(404)
+  end
+
+  # -------------------------------------------------------------------------
+  # http_reason_phrase
+  # -------------------------------------------------------------------------
+
+  def test_http_reason_phrase_known_codes
+    assert_equal 'Unauthorized',       ::Instana::Util.http_reason_phrase(401)
+    assert_equal 'Forbidden',          ::Instana::Util.http_reason_phrase(403)
+    assert_equal 'Not Found',          ::Instana::Util.http_reason_phrase(404)
+    assert_equal 'Method Not Allowed', ::Instana::Util.http_reason_phrase(405)
+    assert_equal 'Internal Server Error', ::Instana::Util.http_reason_phrase(500)
+  end
+
+  def test_http_reason_phrase_unknown_code_returns_nil
+    assert_nil ::Instana::Util.http_reason_phrase(499)
   end
 end


### PR DESCRIPTION
Adds a configurable option to mark HTTP 4xx responses as erroneous spans, and adapts the excon, net-http, and rest-client instrumentations to respect this setting.

Changes:

New http_4xx_as_error config option in config.rb
Instana::Util::Http helper for shared HTTP error classification logic
Updated excon and net-http instrumentation to use the new helper
Full test coverage across all affected instrumentations and the config/util layer